### PR TITLE
Move all public methods to the api namespace

### DIFF
--- a/CHANGES/16.doc.rst
+++ b/CHANGES/16.doc.rst
@@ -1,1 +1,1 @@
-Added API documentation for the :func:`propcache.cached_property` and :func:`propcache.under_cached_property` decorators -- by :user:`bdraco`.
+Added API documentation for the :func:`propcache.api.cached_property` and :func:`propcache.api.under_cached_property` decorators -- by :user:`bdraco`.

--- a/CHANGES/19.breaking.rst
+++ b/CHANGES/19.breaking.rst
@@ -1,0 +1,1 @@
+Moved ``under_cached_property`` and ``cached_property`` to ``propcache.api`` -- by :user:`bdraco`.

--- a/CHANGES/19.breaking.rst
+++ b/CHANGES/19.breaking.rst
@@ -1,1 +1,1 @@
-Moved ``under_cached_property`` and ``cached_property`` to ``propcache.api`` -- by :user:`bdraco`.
+Moved :func:`under_cached_property` and :func:`cached_property` to ``propcache.api`` -- by :user:`bdraco`.

--- a/CHANGES/19.breaking.rst
+++ b/CHANGES/19.breaking.rst
@@ -1,1 +1,1 @@
-Moved :func:`under_cached_property` and :func:`cached_property` to ``propcache.api`` -- by :user:`bdraco`.
+Moved :func:`propcache.api.under_cached_property` and :func:`propcache.api.cached_property` to ``propcache.api`` -- by :user:`bdraco`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,6 +34,8 @@ under_cached_property
 
    Example::
 
+       from propcache.api import under_cached_property
+
        class MyClass:
 
            def __init__(self, data: List[float]):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,7 +4,7 @@
 Reference
 =========
 
-.. module:: propcache
+.. module:: propcache.api
 
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,7 +15,7 @@ cached_property
 
    This decorator functions exactly the same as the standard library
    :func:`cached_property` decorator, but it's available in the
-   :mod:`propcache` module along with an accelerated Cython version.
+   :mod:`propcache.api` module along with an accelerated Cython version.
 
    As with the standard library version, the cached value is stored in
    the instance's ``__dict__`` dictionary. To clear a cached value, you

--- a/propcache/__init__.py
+++ b/propcache/__init__.py
@@ -1,8 +1,1 @@
-from ._helpers import cached_property, under_cached_property
-
 __version__ = "0.1.0.dev0"
-
-__all__ = (
-    "cached_property",
-    "under_cached_property",
-)

--- a/propcache/__init__.py
+++ b/propcache/__init__.py
@@ -1,3 +1,6 @@
 """propcache: An accelerated property cache for Python classes."""
 
 __version__ = "1.0.0.dev0"
+
+# Imports have moved to `propcache.api` in 1.0.0+.
+__all__ = ()

--- a/propcache/__init__.py
+++ b/propcache/__init__.py
@@ -1,1 +1,3 @@
-__version__ = "0.1.0.dev0"
+"""propcache: An accelerated property cache for Python classes."""
+
+__version__ = "1.0.0.dev0"

--- a/propcache/api.py
+++ b/propcache/api.py
@@ -1,3 +1,5 @@
+"""Public API of the property caching library."""
+
 from ._helpers import cached_property, under_cached_property
 
 __all__ = (

--- a/propcache/api.py
+++ b/propcache/api.py
@@ -1,0 +1,6 @@
+from ._helpers import cached_property, under_cached_property
+
+__all__ = (
+    "cached_property",
+    "under_cached_property",
+)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Move public methods to the `api` namespace.

## Are there changes in behavior for the user?

The top level module no longer provides the `cached_property` and `under_cached_property` methods.  They have moved to `propcache.api.cached_property` and `propcache.api.under_cached_property` respectively.

## Related issue number
#18