### PR TITLE
Add coverage to ensure the public API remains usable

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,11 @@
+"""Test we do not break the public API."""
+
+from propcache import _helpers, api
+
+
+def test_api():
+    """Verify the public API is accessible."""
+    assert api.cached_property is not None
+    assert api.under_cached_property is not None
+    assert api.cached_property is _helpers.cached_property
+    assert api.under_cached_property is _helpers.under_cached_property


### PR DESCRIPTION
Since moving to `propcache.api`, we didn't have any coverage that it was usable externally.