### PR TITLE
Add import compat layer to __init__

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -38,6 +38,6 @@ coverage:
       typing:
         flags:
         - MyPy
-        target: 70%  # 100%
+        target: 68.5%  # 100%
 
 ...

--- a/CHANGES/19.breaking.rst
+++ b/CHANGES/19.breaking.rst
@@ -1,1 +1,0 @@
-Moved :func:`propcache.api.under_cached_property` and :func:`propcache.api.cached_property` to ``propcache.api`` -- by :user:`bdraco`.

--- a/CHANGES/19.packaging.rst
+++ b/CHANGES/19.packaging.rst
@@ -1,0 +1,3 @@
+Moved :func:`propcache.api.under_cached_property` and :func:`propcache.api.cached_property` to ``propcache.api`` -- by :user:`bdraco`.
+
+Both decorators remain importable from the top-level package, however importing from `propcache.api` is now the recommended way to use them.

--- a/CHANGES/24.feature.rst
+++ b/CHANGES/24.feature.rst
@@ -1,0 +1,1 @@
+Restored the ability to import :func:`propcache.api.under_cached_property` and :func:`propcache.api.cached_property` directly from ``propcache`` -- by :user:`bdraco`.

--- a/CHANGES/24.feature.rst
+++ b/CHANGES/24.feature.rst
@@ -1,1 +1,0 @@
-Restored the ability to import :func:`propcache.api.under_cached_property` and :func:`propcache.api.cached_property` directly from ``propcache`` -- by :user:`bdraco`.

--- a/CHANGES/24.packaging.rst
+++ b/CHANGES/24.packaging.rst
@@ -1,0 +1,1 @@
+19.packaging.rst

--- a/src/propcache/__init__.py
+++ b/src/propcache/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, List
 
-__version__ = "1.0.0.dev0"
+__version__ = "0.2.0.dev0"
 
 # Imports have moved to `propcache.api` in 1.0.0+.
 # This module is now a facade for the API.

--- a/src/propcache/__init__.py
+++ b/src/propcache/__init__.py
@@ -1,6 +1,30 @@
 """propcache: An accelerated property cache for Python classes."""
 
+from typing import TYPE_CHECKING, List
+
 __version__ = "1.0.0.dev0"
 
 # Imports have moved to `propcache.api` in 1.0.0+.
-__all__ = ()
+# This module is now a facade for the API.
+if TYPE_CHECKING:
+    from .api import cached_property, under_cached_property
+
+__all__ = ("cached_property", "under_cached_property")
+
+
+def _import_facade(attr: str) -> object:
+    """Import the public API from the `api` module."""
+    if attr in __all__:
+        from . import api  # pylint: disable=import-outside-toplevel
+
+        return getattr(api, attr)
+    raise AttributeError(f"module 'propcache' has no attribute '{attr}'")
+
+
+def _dir_facade() -> List[str]:
+    """Include the public API in the module's dir() output."""
+    return [*__all__, *globals().keys()]
+
+
+__getattr__ = _import_facade
+__dir__ = _dir_facade

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,16 +14,22 @@ def test_api_at_top_level():
     assert propcache.under_cached_property is _helpers.under_cached_property
 
 
-def test_public_api_is_in_dir():
-    """Verify the public API is accessible in the module's dir()."""
-    assert "cached_property" in dir(propcache)
-    assert "under_cached_property" in dir(propcache)
+@pytest.mark.parametrize(
+    'prop_name',
+    ('cached_property', 'under_cached_property'),
+)
+@pytest.mark.parametrize(
+    'api_list',
+    (dir(propcache), propcache.__all__),
+    ids=('dir', '__all__')
+)
+def test_public_api_is_in_inspectable_object_lists(prop_name, api_list):
+    """Verify the public API is discoverable programmatically.
 
-
-def test_public_api_is_in_all():
-    """Verify the public API is accessible in the module's __all__."""
-    assert "cached_property" in propcache.__all__
-    assert "under_cached_property" in propcache.__all__
+    This checks for presence of known public decorators module's
+    ``__all__`` and ``dir()``.
+    """
+    assert prop_name in api_list
 
 
 def test_importing_invalid_attr_raises():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,13 +15,11 @@ def test_api_at_top_level():
 
 
 @pytest.mark.parametrize(
-    'prop_name',
-    ('cached_property', 'under_cached_property'),
+    "prop_name",
+    ("cached_property", "under_cached_property"),
 )
 @pytest.mark.parametrize(
-    'api_list',
-    (dir(propcache), propcache.__all__),
-    ids=('dir', '__all__')
+    "api_list", (dir(propcache), propcache.__all__), ids=("dir", "__all__")
 )
 def test_public_api_is_in_inspectable_object_lists(prop_name, api_list):
     """Verify the public API is discoverable programmatically.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,12 @@
+"""Test imports can happen from top-level."""
+
+import propcache
+from propcache import _helpers
+
+
+def test_api_at_top_level():
+    """Verify the public API is accessible at top-level."""
+    assert propcache.cached_property is not None
+    assert propcache.under_cached_property is not None
+    assert propcache.cached_property is _helpers.cached_property
+    assert propcache.under_cached_property is _helpers.under_cached_property

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,7 @@
 """Test imports can happen from top-level."""
 
+import pytest
+
 import propcache
 from propcache import _helpers
 
@@ -10,3 +12,22 @@ def test_api_at_top_level():
     assert propcache.under_cached_property is not None
     assert propcache.cached_property is _helpers.cached_property
     assert propcache.under_cached_property is _helpers.under_cached_property
+
+
+def test_public_api_is_in_dir():
+    """Verify the public API is accessible in the module's dir()."""
+    assert "cached_property" in dir(propcache)
+    assert "under_cached_property" in dir(propcache)
+
+
+def test_public_api_is_in_all():
+    """Verify the public API is accessible in the module's __all__."""
+    assert "cached_property" in propcache.__all__
+    assert "under_cached_property" in propcache.__all__
+
+
+def test_importing_invalid_attr_raises():
+    """Verify importing an invalid attribute raises an AttributeError."""
+    match = r"module 'propcache' has no attribute 'invalid_attr'"
+    with pytest.raises(AttributeError, match=match):
+        propcache.invalid_attr

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -31,3 +31,11 @@ def test_importing_invalid_attr_raises():
     match = r"^module 'propcache' has no attribute 'invalid_attr'$"
     with pytest.raises(AttributeError, match=match):
         propcache.invalid_attr
+
+
+def test_import_error_invalid_attr():
+    """Verify importing an invalid attribute raises an ImportError."""
+    # No match here because the error is raised by the import system
+    # and may vary between Python versions.
+    with pytest.raises(ImportError):
+        from propcache import invalid_attr  # noqa: F401

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,6 +28,6 @@ def test_public_api_is_in_all():
 
 def test_importing_invalid_attr_raises():
     """Verify importing an invalid attribute raises an AttributeError."""
-    match = r"module 'propcache' has no attribute 'invalid_attr'"
+    match = r"^module 'propcache' has no attribute 'invalid_attr'$"
     with pytest.raises(AttributeError, match=match):
         propcache.invalid_attr


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add import compat layer to __init__ so the public API can continue to be imported at top level

## Are there changes in behavior for the user?

Restores the ability to import from top-level

## Related issue number
#18