### PR TITLE
Fix importing the C extensions on Python 3.8

### DIFF
--- a/CHANGES/26.bugfix.rst
+++ b/CHANGES/26.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed loading the C-extensions on Python 3.8 -- by :user:`bdraco`.

--- a/src/propcache/_helpers_c.pyx
+++ b/src/propcache/_helpers_c.pyx
@@ -1,5 +1,13 @@
 # cython: language_level=3
-from types import GenericAlias
+import sys
+import types
+
+if sys.version_info >= (3, 9):
+    GenericAlias = types.GenericAlias
+else:
+
+    def GenericAlias(cls):
+        return cls
 
 
 cdef _sentinel = object()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`GenericAlias` is not available on python 3.8, and the c-ext tried to import it so it would fallback to the pure-python version silently.

## Are there changes in behavior for the user?

bugfix
