### PR TITLE
Revert adding src to pytest pythonpath

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -85,6 +85,4 @@ norecursedirs =
 
 testpaths = tests/
 
-pythonpath = src
-
 xfail_strict = true


### PR DESCRIPTION
This turned out to not be needed from #22 and `__init__.py` file should have been added to the tests instead to always ensure we are testing the installed version.