### PR TITLE
Revert "Release 1.0.0 (#21)"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,33 +14,6 @@ Changelog
 
 .. towncrier release notes start
 
-1.0.0
-=====
-
-*(2024-10-05)*
-
-
-Removals and backward incompatible breaking changes
----------------------------------------------------
-
-- Moved :func:`propcache.api.under_cached_property` and :func:`propcache.api.cached_property` to ``propcache.api`` -- by :user:`bdraco`.
-
-  *Related issues and pull requests on GitHub:*
-  :issue:`19`.
-
-
-Improved documentation
-----------------------
-
-- Added API documentation for the :func:`propcache.api.cached_property` and :func:`propcache.api.under_cached_property` decorators -- by :user:`bdraco`.
-
-  *Related issues and pull requests on GitHub:*
-  :issue:`16`.
-
-
-----
-
-
 0.1.0
 =====
 

--- a/CHANGES/16.doc.rst
+++ b/CHANGES/16.doc.rst
@@ -1,0 +1,1 @@
+Added API documentation for the :func:`propcache.api.cached_property` and :func:`propcache.api.under_cached_property` decorators -- by :user:`bdraco`.

--- a/CHANGES/19.breaking.rst
+++ b/CHANGES/19.breaking.rst
@@ -1,0 +1,1 @@
+Moved :func:`propcache.api.under_cached_property` and :func:`propcache.api.cached_property` to ``propcache.api`` -- by :user:`bdraco`.

--- a/src/propcache/__init__.py
+++ b/src/propcache/__init__.py
@@ -1,6 +1,6 @@
 """propcache: An accelerated property cache for Python classes."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.0.dev0"
 
 # Imports have moved to `propcache.api` in 1.0.0+.
 __all__ = ()


### PR DESCRIPTION
This reverts commit fd4f1350a418826fb4fe2bd398c6812928eb6120.

This release failed and we are going to rework the changelog https://github.com/aio-libs/propcache/pull/24#discussion_r1789201050