### PR TITLE
Adjust imports to ensure wildcard imports are prohibited

### DIFF
--- a/CHANGES/32.packaging.rst
+++ b/CHANGES/32.packaging.rst
@@ -1,0 +1,1 @@
+19.packaging.rst

--- a/src/propcache/__init__.py
+++ b/src/propcache/__init__.py
@@ -10,7 +10,8 @@ __all__ = ()
 # Imports have moved to `propcache.api` in 0.2.0+.
 # This module is now a facade for the API.
 if TYPE_CHECKING:
-    from .api import cached_property, under_cached_property  # noqa: F401
+    from .api import cached_property as cached_property  # noqa: F401
+    from .api import under_cached_property as under_cached_property  # noqa: F401
 
 
 def _import_facade(attr: str) -> object:

--- a/src/propcache/__init__.py
+++ b/src/propcache/__init__.py
@@ -2,28 +2,29 @@
 
 from typing import TYPE_CHECKING, List
 
+_PUBLIC_API = ("cached_property", "under_cached_property")
+
 __version__ = "0.2.0.dev0"
+__all__ = ()
 
 # Imports have moved to `propcache.api` in 0.2.0+.
 # This module is now a facade for the API.
 if TYPE_CHECKING:
-    from .api import cached_property, under_cached_property
-
-__all__ = ("cached_property", "under_cached_property")
+    from .api import cached_property, under_cached_property  # noqa: F401
 
 
 def _import_facade(attr: str) -> object:
     """Import the public API from the `api` module."""
-    if attr in __all__:
+    if attr in _PUBLIC_API:
         from . import api  # pylint: disable=import-outside-toplevel
 
         return getattr(api, attr)
-    raise AttributeError(f"module 'propcache' has no attribute '{attr}'")
+    raise AttributeError(f"module '{__package__}' has no attribute '{attr}'")
 
 
 def _dir_facade() -> List[str]:
     """Include the public API in the module's dir() output."""
-    return [*__all__, *globals().keys()]
+    return [*_PUBLIC_API, *globals().keys()]
 
 
 __getattr__ = _import_facade

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -18,16 +18,9 @@ def test_api_at_top_level():
     "prop_name",
     ("cached_property", "under_cached_property"),
 )
-@pytest.mark.parametrize(
-    "api_list", (dir(propcache), propcache.__all__), ids=("dir", "__all__")
-)
-def test_public_api_is_in_inspectable_object_lists(prop_name, api_list):
-    """Verify the public API is discoverable programmatically.
-
-    This checks for presence of known public decorators module's
-    ``__all__`` and ``dir()``.
-    """
-    assert prop_name in api_list
+def test_public_api_is_discoverable_in_dir(prop_name: str):
+    """Verify the public API is discoverable programmatically."""
+    assert prop_name in dir(propcache)
 
 
 def test_importing_invalid_attr_raises():
@@ -43,3 +36,8 @@ def test_import_error_invalid_attr():
     # and may vary between Python versions.
     with pytest.raises(ImportError):
         from propcache import invalid_attr  # noqa: F401
+
+
+def test_no_wildcard_imports():
+    """Verify wildcard imports are prohibited."""
+    assert not propcache.__all__


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

We do not want to support wildcard imports, make sure they do not work.

Note that I did not mark this as a breaking change as this library is too new and I don't think anyone else is using it yet.

https://github.com/aio-libs/propcache/pull/24#discussion_r1789283778

## Are there changes in behavior for the user?

Wildcard imports are no longer supported

## Related issue number
