### PR TITLE
Remove no cover lines from under_cached_property.__get__

### DIFF
--- a/src/propcache/_helpers_py.py
+++ b/src/propcache/_helpers_py.py
@@ -46,14 +46,10 @@ class under_cached_property(Generic[_T]):
         self.name = wrapped.__name__
 
     @overload
-    def __get__(  # pragma: no cover
-        self, inst: None, owner: Optional[Type[Any]] = None
-    ) -> Self: ...  # pragma: no cover
+    def __get__(self, inst: None, owner: Optional[Type[Any]] = None) -> Self: ...
 
     @overload
-    def __get__(  # pragma: no cover
-        self, inst: _TSelf[_T], owner: Optional[Type[Any]] = None
-    ) -> _T: ...  # pragma: no cover
+    def __get__(self, inst: _TSelf[_T], owner: Optional[Type[Any]] = None) -> _T: ...
 
     def __get__(
         self, inst: Optional[_TSelf[_T]], owner: Optional[Type[Any]] = None

--- a/src/propcache/_helpers_py.py
+++ b/src/propcache/_helpers_py.py
@@ -46,12 +46,10 @@ class under_cached_property(Generic[_T]):
         self.name = wrapped.__name__
 
     @overload
-    def __get__(self, inst: None, owner: Optional[Type[Any]] = None) -> Self:
-        ...
+    def __get__(self, inst: None, owner: Optional[Type[Any]] = None) -> Self: ...
 
     @overload
-    def __get__(self, inst: _TSelf[_T], owner: Optional[Type[Any]] = None) -> _T:
-        ...
+    def __get__(self, inst: _TSelf[_T], owner: Optional[Type[Any]] = None) -> _T: ...
 
     def __get__(
         self, inst: Optional[_TSelf[_T]], owner: Optional[Type[Any]] = None

--- a/src/propcache/_helpers_py.py
+++ b/src/propcache/_helpers_py.py
@@ -46,10 +46,12 @@ class under_cached_property(Generic[_T]):
         self.name = wrapped.__name__
 
     @overload
-    def __get__(self, inst: None, owner: Optional[Type[Any]] = None) -> Self: ...
+    def __get__(self, inst: None, owner: Optional[Type[Any]] = None) -> Self:
+        ...
 
     @overload
-    def __get__(self, inst: _TSelf[_T], owner: Optional[Type[Any]] = None) -> _T: ...
+    def __get__(self, inst: _TSelf[_T], owner: Optional[Type[Any]] = None) -> _T:
+        ...
 
     def __get__(
         self, inst: Optional[_TSelf[_T]], owner: Optional[Type[Any]] = None


### PR DESCRIPTION
These should already be handled by covdefaults
