### PR TITLE
Change type from Any to object for under_cached_property.__get__

### DIFF
--- a/src/propcache/_helpers_py.py
+++ b/src/propcache/_helpers_py.py
@@ -46,13 +46,13 @@ class under_cached_property(Generic[_T]):
         self.name = wrapped.__name__
 
     @overload
-    def __get__(self, inst: None, owner: Optional[Type[Any]] = None) -> Self: ...
+    def __get__(self, inst: None, owner: Optional[Type[object]] = None) -> Self: ...
 
     @overload
-    def __get__(self, inst: _TSelf[_T], owner: Optional[Type[Any]] = None) -> _T: ...
+    def __get__(self, inst: _TSelf[_T], owner: Optional[Type[object]] = None) -> _T: ...
 
     def __get__(
-        self, inst: Optional[_TSelf[_T]], owner: Optional[Type[Any]] = None
+        self, inst: Optional[_TSelf[_T]], owner: Optional[Type[object]] = None
     ) -> Union[_T, Self]:
         if inst is None:
             return self


### PR DESCRIPTION
> If the implementation is type safe with anything, then it should be updated to object. I've had discussions in typeshed before, and the consensus is that typeshed should use object in such circumstances (otherwise, it triggers Any warnings in mypy if all the any warnings are enabled, anytime a user uses that function).

_Originally posted by @Dreamsorcerer in https://github.com/aio-libs/propcache/pull/38#discussion_r1790880159_
            
