### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@
 
 codecov:
   notify:
-    after_n_builds: 24  # The number of test matrix+lint jobs uploading coverage
+    after_n_builds: 23  # The number of test matrix+lint jobs uploading coverage
     wait_for_ci: false
 
   require_ci_to_pass: false

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -174,7 +174,6 @@ jobs:
         - >-
           3.10
         - 3.9
-        - 3.8
         no-extensions: ['', 'Y']
         os:
         - ubuntu-latest
@@ -192,10 +191,6 @@ jobs:
           experimental: false
           os: ubuntu-latest
         - pyver: pypy-3.9
-          no-extensions: Y
-          experimental: false
-          os: ubuntu-latest
-        - pyver: pypy-3.8
           no-extensions: Y
           experimental: false
           os: ubuntu-latest

--- a/.github/workflows/reusable-linters.yml
+++ b/.github/workflows/reusable-linters.yml
@@ -63,8 +63,9 @@ jobs:
       with:
         token: ${{ secrets.codecov-token }}
         files: >-
+          .tox/.tmp/.mypy/python-3.13/cobertura.xml,
           .tox/.tmp/.mypy/python-3.12/cobertura.xml,
-          .tox/.tmp/.mypy/python-3.10/cobertura.xml,
+          .tox/.tmp/.mypy/python-3.11/cobertura.xml,
           .tox/.tmp/.mypy/python-3.9/cobertura.xml
         flags: >-
           CI-GHA,

--- a/.github/workflows/reusable-linters.yml
+++ b/.github/workflows/reusable-linters.yml
@@ -65,7 +65,7 @@ jobs:
         files: >-
           .tox/.tmp/.mypy/python-3.12/cobertura.xml,
           .tox/.tmp/.mypy/python-3.10/cobertura.xml,
-          .tox/.tmp/.mypy/python-3.8/cobertura.xml
+          .tox/.tmp/.mypy/python-3.9/cobertura.xml
         flags: >-
           CI-GHA,
           MyPy

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.9
 color_output = true
 error_summary = true
 files =

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
   rev: 'v3.17.0'
   hooks:
   - id: pyupgrade
-    args: ['--py38-plus']
+    args: ['--py39-plus']
 - repo: https://github.com/PyCQA/flake8
   rev: '7.1.1'
   hooks:
@@ -138,8 +138,8 @@ repos:
     - --html-report=.tox/.tmp/.mypy/python-3.12
     pass_filenames: false
   - id: mypy
-    alias: mypy-py310
-    name: MyPy, for Python 3.10
+    alias: mypy-py311
+    name: MyPy, for Python 3.11
     additional_dependencies:
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
@@ -148,10 +148,10 @@ repos:
     - types-Pygments
     - types-colorama
     args:
-    - --python-version=3.10
-    - --txt-report=.tox/.tmp/.mypy/python-3.10
-    - --cobertura-xml-report=.tox/.tmp/.mypy/python-3.10
-    - --html-report=.tox/.tmp/.mypy/python-3.10
+    - --python-version=3.11
+    - --txt-report=.tox/.tmp/.mypy/python-3.11
+    - --cobertura-xml-report=.tox/.tmp/.mypy/python-3.11
+    - --html-report=.tox/.tmp/.mypy/python-3.11
     pass_filenames: false
   - id: mypy
     alias: mypy-py39

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,8 +154,8 @@ repos:
     - --html-report=.tox/.tmp/.mypy/python-3.10
     pass_filenames: false
   - id: mypy
-    alias: mypy-py38
-    name: MyPy, for Python 3.8
+    alias: mypy-py39
+    name: MyPy, for Python 3.9
     additional_dependencies:
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
@@ -164,10 +164,10 @@ repos:
     - types-Pygments
     - types-colorama
     args:
-    - --python-version=3.8
-    - --txt-report=.tox/.tmp/.mypy/python-3.8
-    - --cobertura-xml-report=.tox/.tmp/.mypy/python-3.8
-    - --html-report=.tox/.tmp/.mypy/python-3.8
+    - --python-version=3.9
+    - --txt-report=.tox/.tmp/.mypy/python-3.9
+    - --cobertura-xml-report=.tox/.tmp/.mypy/python-3.9
+    - --html-report=.tox/.tmp/.mypy/python-3.9
     pass_filenames: false
 
 - repo: https://github.com/rhysd/actionlint.git

--- a/CHANGES/57.breaking.rst
+++ b/CHANGES/57.breaking.rst
@@ -1,0 +1,1 @@
+Removed support for Python 3.8 as it has reached end of life -- by :user:`bdraco`.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 propcache
 =========
 
-The module provides a fast implementation of cached properties for Python 3.8+.
+The module provides a fast implementation of cached properties for Python 3.9+.
 
 .. image:: https://github.com/aio-libs/propcache/actions/workflows/ci-cd.yml/badge.svg
   :target: https://github.com/aio-libs/propcache/actions?query=workflow%3ACI

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ classifiers =
   Programming Language :: Cython
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
@@ -53,7 +52,7 @@ keywords =
   propcache
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.9
 # Ref:
 # https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#using-a-src-layout
 # (`src/` layout)

--- a/src/propcache/__init__.py
+++ b/src/propcache/__init__.py
@@ -1,6 +1,6 @@
 """propcache: An accelerated property cache for Python classes."""
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 _PUBLIC_API = ("cached_property", "under_cached_property")
 
@@ -23,7 +23,7 @@ def _import_facade(attr: str) -> object:
     raise AttributeError(f"module '{__package__}' has no attribute '{attr}'")
 
 
-def _dir_facade() -> List[str]:
+def _dir_facade() -> list[str]:
     """Include the public API in the module's dir() output."""
     return [*_PUBLIC_API, *globals().keys()]
 

--- a/src/propcache/_helpers_c.pyx
+++ b/src/propcache/_helpers_c.pyx
@@ -1,13 +1,5 @@
 # cython: language_level=3
-import sys
-import types
-
-if sys.version_info >= (3, 9):
-    GenericAlias = types.GenericAlias
-else:
-
-    def GenericAlias(cls):
-        return cls
+from types import GenericAlias
 
 
 cdef _sentinel = object()

--- a/src/propcache/_helpers_py.py
+++ b/src/propcache/_helpers_py.py
@@ -2,18 +2,7 @@
 
 import sys
 from functools import cached_property
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    Optional,
-    Protocol,
-    Type,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Callable, Generic, Optional, Protocol, TypeVar, Union, overload
 
 __all__ = ("under_cached_property", "cached_property")
 
@@ -27,7 +16,7 @@ _T = TypeVar("_T")
 
 
 class _TSelf(Protocol, Generic[_T]):
-    _cache: Dict[str, _T]
+    _cache: dict[str, _T]
 
 
 class under_cached_property(Generic[_T]):
@@ -46,13 +35,13 @@ class under_cached_property(Generic[_T]):
         self.name = wrapped.__name__
 
     @overload
-    def __get__(self, inst: None, owner: Optional[Type[object]] = None) -> Self: ...
+    def __get__(self, inst: None, owner: Optional[type[object]] = None) -> Self: ...
 
     @overload
-    def __get__(self, inst: _TSelf[_T], owner: Optional[Type[object]] = None) -> _T: ...
+    def __get__(self, inst: _TSelf[_T], owner: Optional[type[object]] = None) -> _T: ...
 
     def __get__(
-        self, inst: Optional[_TSelf[_T]], owner: Optional[Type[object]] = None
+        self, inst: Optional[_TSelf[_T]], owner: Optional[type[object]] = None
     ) -> Union[_T, Self]:
         if inst is None:
             return self

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ def pytest_addoption(
 def pytest_collection_modifyitems(
     session: pytest.Session,
     config: pytest.Config,
-    items: List[pytest.Item],
+    items: list[pytest.Item],
 ) -> None:
     """Deselect tests against C-extensions when requested via CLI."""
     test_c_extensions = config.getoption("--c-extensions") is True
@@ -95,8 +95,8 @@ def pytest_collection_modifyitems(
     if test_c_extensions:
         return
 
-    selected_tests: List[pytest.Item] = []
-    deselected_tests: List[pytest.Item] = []
+    selected_tests: list[pytest.Item] = []
+    deselected_tests: list[pytest.Item] = []
 
     for item in items:
         c_ext = item.get_closest_marker(C_EXT_MARK.name) is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from functools import cached_property
 from importlib import import_module
 from types import ModuleType
-from typing import List
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,12 @@ import argparse
 from dataclasses import dataclass
 from functools import cached_property
 from importlib import import_module
-from sys import version_info as _version_info
 from types import ModuleType
-from typing import List, Type, Union
+from typing import List
 
 import pytest
 
 C_EXT_MARK = pytest.mark.c_extension
-PY_38_AND_BELOW = _version_info < (3, 9)
 
 
 @dataclass(frozen=True)
@@ -77,28 +75,13 @@ def pytest_addoption(
     version of the ``propcache`` implementation.
     """
     del pluginmanager
-
-    arg_parse_action: Union[str, Type[argparse.Action]]
-    if PY_38_AND_BELOW:
-        arg_parse_action = "store_true"
-    else:
-        arg_parse_action = argparse.BooleanOptionalAction  # type: ignore[attr-defined, unused-ignore]  # noqa
-
     parser.addoption(
         "--c-extensions",  # disabled with `--no-c-extensions`
-        action=arg_parse_action,
+        action=argparse.BooleanOptionalAction,
         default=True,
         dest="c_extensions",
         help="Test C-extensions (on by default)",
     )
-
-    if PY_38_AND_BELOW:
-        parser.addoption(
-            "--no-c-extensions",
-            action="store_false",
-            dest="c_extensions",
-            help="Skip testing C-extensions (on by default)",
-        )
 
 
 def pytest_collection_modifyitems(

--- a/tests/test_cached_property.py
+++ b/tests/test_cached_property.py
@@ -1,5 +1,5 @@
 from operator import not_
-from typing import Protocol, Type
+from typing import Protocol
 
 import pytest
 
@@ -8,7 +8,7 @@ from propcache.api import cached_property
 
 class APIProtocol(Protocol):
 
-    cached_property: Type[cached_property]
+    cached_property: type[cached_property]
 
 
 def test_cached_property(propcache_module: APIProtocol) -> None:

--- a/tests/test_under_cached_property.py
+++ b/tests/test_under_cached_property.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Protocol, Type
+from typing import Any, Protocol
 
 import pytest
 
@@ -7,13 +7,13 @@ from propcache.api import under_cached_property
 
 class APIProtocol(Protocol):
 
-    under_cached_property: Type[under_cached_property]
+    under_cached_property: type[under_cached_property]
 
 
 def test_under_cached_property(propcache_module: APIProtocol) -> None:
     class A:
         def __init__(self) -> None:
-            self._cache: Dict[str, int] = {}
+            self._cache: dict[str, int] = {}
 
         @propcache_module.under_cached_property
         def prop(self) -> int:
@@ -39,7 +39,7 @@ def test_under_cached_property_class(propcache_module: APIProtocol) -> None:
 def test_under_cached_property_assignment(propcache_module: APIProtocol) -> None:
     class A:
         def __init__(self) -> None:
-            self._cache: Dict[str, Any] = {}
+            self._cache: dict[str, Any] = {}
 
         @propcache_module.under_cached_property
         def prop(self) -> None:
@@ -55,7 +55,7 @@ def test_under_cached_property_without_cache(propcache_module: APIProtocol) -> N
     class A:
         def __init__(self) -> None:
             """Init."""
-            self._cache: Dict[str, int] = {}
+            self._cache: dict[str, int] = {}
 
         @propcache_module.under_cached_property
         def prop(self) -> None:
@@ -88,7 +88,7 @@ def test_under_cached_property_check_without_cache(
 def test_under_cached_property_caching(propcache_module: APIProtocol) -> None:
     class A:
         def __init__(self) -> None:
-            self._cache: Dict[str, int] = {}
+            self._cache: dict[str, int] = {}
 
         @propcache_module.under_cached_property
         def prop(self) -> int:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Drop Python 3.8 support

3.8 has reached EOL as of the 7th of October https://devguide.python.org/versions/

## Are there changes in behavior for the user?

Drop Python 3.8 support
