### PR TITLE
Add benchmarks for cache miss

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -5,8 +5,8 @@ from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
 from propcache import cached_property, under_cached_property
 
 
-def test_under_cached_property_caching(benchmark: BenchmarkFixture) -> None:
-    """Benchmark for under_cached_property caching."""
+def test_under_cached_property_cache_hit(benchmark: BenchmarkFixture) -> None:
+    """Benchmark for under_cached_property cache hit."""
 
     class Test:
         def __init__(self) -> None:
@@ -25,8 +25,8 @@ def test_under_cached_property_caching(benchmark: BenchmarkFixture) -> None:
             t.prop
 
 
-def test_cached_property_caching(benchmark: BenchmarkFixture) -> None:
-    """Benchmark for cached_property caching."""
+def test_cached_property_cache_hit(benchmark: BenchmarkFixture) -> None:
+    """Benchmark for cached_property cache hit."""
 
     class Test:
         def __init__(self) -> None:
@@ -42,4 +42,46 @@ def test_cached_property_caching(benchmark: BenchmarkFixture) -> None:
     @benchmark
     def _run() -> None:
         for _ in range(100):
+            t.prop
+
+
+def test_under_cached_property_cache_miss(benchmark: BenchmarkFixture) -> None:
+    """Benchmark for under_cached_property cache miss."""
+
+    class Test:
+        def __init__(self) -> None:
+            self._cache: dict[str, int] = {}
+
+        @under_cached_property
+        def prop(self) -> int:
+            """Return the value of the property."""
+            return 42
+
+    t = Test()
+    cache = t._cache
+
+    @benchmark
+    def _run() -> None:
+        for _ in range(100):
+            cache.pop("prop", None)
+            t.prop
+
+
+def test_cached_property_cache_miss(benchmark: BenchmarkFixture) -> None:
+    """Benchmark for cached_property cache miss."""
+
+    class Test:
+
+        @cached_property
+        def prop(self) -> int:
+            """Return the value of the property."""
+            return 42
+
+    t = Test()
+    cache = t.__dict__
+
+    @benchmark
+    def _run() -> None:
+        for _ in range(100):
+            cache.pop("prop", None)
             t.prop


### PR DESCRIPTION
I realized we should have benchmarks for cache miss as well

Sadly we have to pop out the key every time so that gets included in the benchmark but thats ok as long as we think about that when looking at the data
