### PR TITLE
Cleanup mypy config for codspeed

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -30,11 +30,6 @@ warn_no_return = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 
-[mypy-test_benchmarks]
-disable_error_code =
-  no-any-unimported,
-  misc
-
 [mypy-Cython.*]
 ignore_missing_imports = true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,7 @@ repos:
     additional_dependencies:
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
-    - pytest_codspeed
+    - pytest_codspeed==3.0.0
     - tomli  # requirement of packaging/pep517_backend/
     - types-setuptools  # requirement of packaging/pep517_backend/
     args:
@@ -130,7 +130,7 @@ repos:
     additional_dependencies:
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
-    - pytest_codspeed
+    - pytest_codspeed==3.0.0
     - tomli  # requirement of packaging/pep517_backend/
     - types-setuptools  # requirement of packaging/pep517_backend/
     args:
@@ -145,7 +145,7 @@ repos:
     additional_dependencies:
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
-    - pytest_codspeed
+    - pytest_codspeed==3.0.0
     - tomli  # requirement of packaging/pep517_backend/
     - types-setuptools  # requirement of packaging/pep517_backend/
     - types-Pygments
@@ -162,7 +162,7 @@ repos:
     additional_dependencies:
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
-    - pytest_codspeed
+    - pytest_codspeed==3.0.0
     - tomli  # requirement of packaging/pep517_backend/
     - types-setuptools  # requirement of packaging/pep517_backend/
     - types-Pygments

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,6 +1,6 @@
 """codspeed benchmarks for propcache."""
 
-from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
+from pytest_codspeed import BenchmarkFixture
 
 from propcache import cached_property, under_cached_property
 


### PR DESCRIPTION
For some reason we don't have the full mypy config in this repo, so the dependabot PR didn't error on unused ignores.