### PR TITLE
Ensure wrapped function is accessible in Cython versions

### DIFF
--- a/CHANGES/72.bugfix.rst
+++ b/CHANGES/72.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``wrapped`` and ``func`` not being accessible in the Cython versions of :func:`propcache.api.cached_property` and :func:`propcache.api.under_cached_property` decorators -- by :user:`bdraco`.

--- a/src/propcache/_helpers_c.pyx
+++ b/src/propcache/_helpers_c.pyx
@@ -13,7 +13,7 @@ cdef class under_cached_property:
 
     """
 
-    cdef object wrapped
+    cdef readonly object wrapped
     cdef object name
 
     def __init__(self, wrapped):
@@ -47,16 +47,16 @@ cdef class cached_property:
 
     """
 
-    cdef object wrapped
+    cdef readonly object func
     cdef object name
 
-    def __init__(self, wrapped):
-        self.wrapped = wrapped
+    def __init__(self, func):
+        self.func = func
         self.name = None
 
     @property
     def __doc__(self):
-        return self.wrapped.__doc__
+        return self.func.__doc__
 
     def __set_name__(self, owner, name):
         if self.name is None:
@@ -77,7 +77,7 @@ cdef class cached_property:
         cdef dict cache = inst.__dict__
         val = cache.get(self.name, _sentinel)
         if val is _sentinel:
-            val = self.wrapped(inst)
+            val = self.func(inst)
             cache[self.name] = val
         return val
 

--- a/tests/test_cached_property.py
+++ b/tests/test_cached_property.py
@@ -127,3 +127,19 @@ def test_get_without_set_name(propcache_module: APIProtocol) -> None:
     match = r"Cannot use cached_property instance "
     with pytest.raises(TypeError, match=match):
         _ = A().cp  # type: ignore[attr-defined]
+
+
+def test_ensured_wrapped_function_is_accessible(propcache_module: APIProtocol) -> None:
+    """Test that the wrapped function can be accessed from python."""
+
+    class A:
+        def __init__(self) -> None:
+            """Init."""
+
+        @propcache_module.cached_property
+        def prop(self) -> int:
+            """Docstring."""
+            return 1
+
+    a = A()
+    assert A.prop.func(a) == 1

--- a/tests/test_under_cached_property.py
+++ b/tests/test_under_cached_property.py
@@ -110,3 +110,20 @@ def test_under_cached_property_class_docstring(propcache_module: APIProtocol) ->
 
     assert isinstance(A.prop, propcache_module.under_cached_property)
     assert "Docstring." == A.prop.__doc__
+
+
+def test_ensured_wrapped_function_is_accessible(propcache_module: APIProtocol) -> None:
+    """Test that the wrapped function can be accessed from python."""
+
+    class A:
+        def __init__(self) -> None:
+            """Init."""
+            self._cache: dict[str, int] = {}
+
+        @propcache_module.under_cached_property
+        def prop(self) -> int:
+            """Docstring."""
+            return 1
+
+    a = A()
+    assert A.prop.wrapped(a) == 1


### PR DESCRIPTION
The `wrapped` and `func` values of `under_cached_property` and `cached_property` where only accessible in the pure-python version.

