### PR TITLE
Fix wheel builds when cffi needs to be built from source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,3 +91,6 @@ pure-python = "false"
 
 [tool.cibuildwheel.windows]
 before-test = []  # Windows cmd has different syntax and pip chooses wheels
+
+[tool.cibuildwheel.linux]
+before-all = "yum install -y libffi-devel || apk add --upgrade libffi-dev || apt-get install libffi-dev"


### PR DESCRIPTION
0.2.1 failed to release due to cffi not being able to be built

https://github.com/aio-libs/propcache/actions/runs/12107193824

Same fix as https://github.com/aio-libs/multidict/pull/1015/commits/a60248db44be9ba2601ce20d97564ad10a9502da