### PR TITLE
Split wheel builds to disable manylinux armv7l wheels

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -133,9 +133,24 @@ jobs:
         - ubuntu
         - windows
         - macos
+        tag:
+        - ''
+        - 'musllinux'
+        exclude:
+        - os: windows
+          tag: 'musllinux'
+        - os: macos
+          tag: 'musllinux'
+        - os: ubuntu
+          tag: >-
+           ${{
+           (github.event_name != 'push' || !contains(github.ref, 'refs/tags/'))
+           && 'musllinux' || 'none'
+           }}
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       os: ${{ matrix.os }}
+      tag: ${{ matrix.tag }}
       wheel-tags-to-skip: >-
         ${{
         (github.event_name != 'push' || !contains(github.ref, 'refs/tags/'))
@@ -144,7 +159,8 @@ jobs:
         *-musllinux_*
         *-win32
         pp*'
-        || ''
+        || (matrix.tag == 'musllinux') && '*-manylinux_* pp*'
+        || '*-musllinux_* pp*'
         }}
       source-tarball-name: >-
         ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
@@ -464,9 +480,22 @@ jobs:
         - ppc64le
         - s390x
         - armv7l
+        tag:
+        - ''
+        - musllinux
+        exclude:
+        - tag: ''
+          qemu: armv7l
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       qemu: ${{ matrix.qemu }}
+      tag: ${{ matrix.tag }}
+      wheel-tags-to-skip: >-
+        ${{
+        (matrix.tag == 'musllinux')
+        && '*-manylinux_* pp*'
+        || '*-musllinux_* pp*'
+        }}
       source-tarball-name: >-
         ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
       dists-artifact-name: ${{ needs.pre-setup.outputs.dists-artifact-name }}

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -24,6 +24,11 @@ on:
         default: ''
         required: false
         type: string
+      tag:
+        description: Build platform tag wheels
+        default: ''
+        required: false
+        type: string
       source-tarball-name:
         description: Sdist filename wildcard
         required: true
@@ -42,7 +47,8 @@ env:
 jobs:
 
   build-wheel:
-    name: Build wheels on ${{ inputs.os }} ${{ inputs.qemu }}
+    name: >-
+     Build ${{ inputs.tag }} wheels on ${{ inputs.os }} ${{ inputs.qemu }}
     runs-on: ${{ inputs.os }}-latest
     timeout-minutes: ${{ inputs.qemu && 60 || 20 }}
     steps:
@@ -83,8 +89,10 @@ jobs:
     - name: Upload built artifacts for testing and publishing
       uses: actions/upload-artifact@v4
       with:
-        name: >-
-          ${{ inputs.dists-artifact-name }}-${{ inputs.os }}-${{ inputs.qemu }}
+        name: ${{ inputs.dists-artifact-name }}-
+          ${{ inputs.os }}-
+          ${{ inputs.qemu }}-
+          ${{ inputs.tag }}
         path: ./wheelhouse/*.whl
 
 ...


### PR DESCRIPTION
The image provided by `cibuildwheel` for `manylinux` `armv7l` that was added in 2.22.0 is [experimental](https://github.com/pypa/cibuildwheel/pull/2052) and not capable of building `cffi` packages because its missing `libcffi-dev`

Disable it for now by copying the wheel build config from `yarl` which splits `musllinux` and `manylinux` and already has `armv7l` `manylinux` wheels disabled.

Note that we have never built `armv7l` `manylinux` wheels so this does not have any impact downstream