### PR TITLE
Bump Python version for benchmarks to 3.13

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -384,11 +384,11 @@ jobs:
         pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
         merge-multiple: true
 
-    - name: Setup Python 3.12
+    - name: Setup Python 3.13
       id: python-install
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.13
         cache: pip
         cache-dependency-path: requirements/*.txt
     - name: Install dependencies

--- a/src/propcache/__init__.py
+++ b/src/propcache/__init__.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 _PUBLIC_API = ("cached_property", "under_cached_property")
 
-__version__ = "0.2.1"
+__version__ = "0.2.2.dev0"
 __all__ = ()
 
 # Imports have moved to `propcache.api` in 0.2.0+.


### PR DESCRIPTION
Python 3.13.1 has been released. As its rare to see
performance changes in Python versions after .0, and
even more rare to see them after .1 its time to start
benchmarking against 3.13.1