### PR TITLE
Add qemu workaround to fix wheel builds

### DIFF
--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -63,6 +63,10 @@ jobs:
       uses: docker/setup-qemu-action@v3
       with:
         platforms: all
+        # This should be temporary
+        # xref https://github.com/docker/setup-qemu-action/issues/188
+        # xref https://github.com/tonistiigi/binfmt/issues/215
+        image: tonistiigi/binfmt:qemu-v8.1.5
       id: qemu
     - name: Prepare emulation
       if: inputs.qemu


### PR DESCRIPTION
This is the same workaround used in aiohttp, and other places to fix the seg faults while building wheels. Hopefully it will get solved upstream soon and we can remove the pin

https://github.com/docker/setup-qemu-action/issues/188 (not fixed yet see https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2648600497)
https://github.com/tonistiigi/binfmt/issues/215 