### PR TITLE
Revert "Start building wheels for armv7l manylinux (#94)"

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -511,6 +511,9 @@ jobs:
         tag:
         - ''
         - musllinux
+        exclude:
+        - tag: ''
+          qemu: armv7l
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       qemu: ${{ matrix.qemu }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,11 +37,6 @@ Packaging updates and notes for downstreams
   *Related issues and pull requests on GitHub:*
   :issue:`84`.
 
-- Started building wheels for armv7l manylinux -- by :user:`bdraco`.
-
-  *Related issues and pull requests on GitHub:*
-  :issue:`94`.
-
 
 Contributor-facing changes
 --------------------------

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -12,7 +12,6 @@ Towncrier
 Twitter
 UTF
 aiohttp
-armv
 backend
 boolean
 booleans

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,9 +93,6 @@ pure-python = "false"
 [tool.cibuildwheel.windows]
 before-test = []  # Windows cmd has different syntax and pip chooses wheels
 
-[tool.cibuildwheel.linux]
-before-all = "yum install -y libffi-devel || apk add --upgrade libffi-dev || apt-get install libffi-dev"
-
 # TODO: Remove this when there's a Cython 3.1 final release
 # Remove PIP_CONSTRAINT from the environment
 [[tool.cibuildwheel.overrides]]


### PR DESCRIPTION
This reverts commit 9f8918b
libcffi-dev is not available in the manylinux armv7 images