### PR TITLE
Implement a base class for property caching

### DIFF
--- a/src/propcache/__init__.py
+++ b/src/propcache/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-_PUBLIC_API = ("cached_property", "under_cached_property")
+_PUBLIC_API = ("base_cached_property", "cached_property", "under_cached_property")
 
 __version__ = "0.3.1"
 __all__ = ()
@@ -10,6 +10,8 @@ __all__ = ()
 # Imports have moved to `propcache.api` in 0.2.0+.
 # This module is now a facade for the API.
 if TYPE_CHECKING:
+    from .api import CacheBase as CacheBase  # noqa: F401
+    from .api import base_cached_property as base_cached_property  # noqa: F401
     from .api import cached_property as cached_property  # noqa: F401
     from .api import under_cached_property as under_cached_property  # noqa: F401
 

--- a/src/propcache/_helpers.py
+++ b/src/propcache/_helpers.py
@@ -12,7 +12,7 @@ if sys.implementation.name != "cpython":
 
 # isort: off
 if TYPE_CHECKING:
-    from ._helpers_py import base_cached_property as base_cached_property_py
+    from ._helpers_py import under_cached_property as base_cached_property_py
     from ._helpers_py import cached_property as cached_property_py
     from ._helpers_py import under_cached_property as under_cached_property_py
     from ._helpers_py import CacheBase as CacheBase_py

--- a/src/propcache/_helpers.py
+++ b/src/propcache/_helpers.py
@@ -2,7 +2,7 @@ import os
 import sys
 from typing import TYPE_CHECKING
 
-__all__ = ("cached_property", "under_cached_property")
+__all__ = ("base_cached_property", "cached_property", "under_cached_property")
 
 
 NO_EXTENSIONS = bool(os.environ.get("PROPCACHE_NO_EXTENSIONS"))  # type: bool
@@ -12,28 +12,44 @@ if sys.implementation.name != "cpython":
 
 # isort: off
 if TYPE_CHECKING:
+    from ._helpers_py import base_cached_property as base_cached_property_py
     from ._helpers_py import cached_property as cached_property_py
     from ._helpers_py import under_cached_property as under_cached_property_py
+    from ._helpers_py import CacheBase as CacheBase_py
 
+    base_cached_property = under_cached_property_py
     cached_property = cached_property_py
     under_cached_property = under_cached_property_py
+    CacheBase = CacheBase_py
 elif not NO_EXTENSIONS:  # pragma: no branch
     try:
+        from ._helpers_c import base_cached_property as base_cached_property_c  # type: ignore[attr-defined, unused-ignore]
         from ._helpers_c import cached_property as cached_property_c  # type: ignore[attr-defined, unused-ignore]
         from ._helpers_c import under_cached_property as under_cached_property_c  # type: ignore[attr-defined, unused-ignore]
+        from ._helpers_c import CacheBase as CacheBase_c  # type: ignore[attr-defined, unused-ignore]
 
+        base_cached_property = base_cached_property_c
         cached_property = cached_property_c
         under_cached_property = under_cached_property_c
+        CacheBase = CacheBase_c
     except ImportError:  # pragma: no cover
+        from ._helpers_py import under_cached_property as base_cached_property_py
         from ._helpers_py import cached_property as cached_property_py
         from ._helpers_py import under_cached_property as under_cached_property_py
+        from ._helpers_py import CacheBase as CacheBase_py
 
+        base_cached_property = base_cached_property_py
         cached_property = cached_property_py  # type: ignore[assignment, misc]
         under_cached_property = under_cached_property_py
+        CacheBase = CacheBase_py
 else:
+    from ._helpers_py import under_cached_property as base_cached_property_py
     from ._helpers_py import cached_property as cached_property_py
     from ._helpers_py import under_cached_property as under_cached_property_py
+    from ._helpers_py import CacheBase as CacheBase_py
 
+    base_cached_property = base_cached_property_py
     cached_property = cached_property_py  # type: ignore[assignment, misc]
     under_cached_property = under_cached_property_py
+    CacheBase = CacheBase_py
 # isort: on

--- a/src/propcache/_helpers_c.pyx
+++ b/src/propcache/_helpers_c.pyx
@@ -10,12 +10,15 @@ cdef class CacheBase:
     provides a _cache attribute that is used to store the results of
     cached properties.
 
-    Callers are responsible for creating the _cache attribute.  This is
-    done in the __init__ method of the class that inherits from
-    CachedBase.
+    Callers are responsible for calling super().__init__() in their
+    __init__() methods to ensure that the _cache attribute is
+    initialized.
     """
 
-    cdef dict _cache
+    cdef public dict _cache
+
+    def __init__(self):
+        self._cache = {}
 
 
 cdef class base_cached_property:

--- a/src/propcache/_helpers_c.pyx
+++ b/src/propcache/_helpers_c.pyx
@@ -46,11 +46,10 @@ cdef class base_cached_property:
     def __get__(self, inst, owner):
         if inst is None:
             return self
-        cdef dict cache = (<CacheBase>inst)._cache
-        val = cache.get(self.name, _sentinel)
+        val = (<CacheBase>inst)._cache.get(self.name, _sentinel)
         if val is _sentinel:
             val = self.wrapped(inst)
-            cache[self.name] = val
+            (<CacheBase>inst)._cache[self.name] = val
         return val
 
     def __set__(self, inst, value):

--- a/src/propcache/_helpers_c.pyx
+++ b/src/propcache/_helpers_c.pyx
@@ -50,7 +50,7 @@ cdef class base_cached_property:
         val = cache_inst._cache.get(self.name, _sentinel)
         if val is _sentinel:
             val = self.wrapped(inst)
-            (<CacheBase>inst)._cache[self.name] = val
+            cache_inst._cache[self.name] = val
         return val
 
     def __set__(self, inst, value):

--- a/src/propcache/_helpers_c.pyx
+++ b/src/propcache/_helpers_c.pyx
@@ -27,7 +27,7 @@ cdef class base_cached_property:
     method it decorates into the instance dict after the first call,
     effectively replacing the function it decorates with an instance
     variable.  It is, in Python parlance, a data descriptor. This version
-    requires that the base class CachedBase is used, which provides
+    requires that the base class CacheBase is used, which provides
     the _cache attribute.
 
     """

--- a/src/propcache/_helpers_c.pyx
+++ b/src/propcache/_helpers_c.pyx
@@ -46,7 +46,8 @@ cdef class base_cached_property:
     def __get__(self, inst, owner):
         if inst is None:
             return self
-        val = (<CacheBase>inst)._cache.get(self.name, _sentinel)
+        cdef CacheBase cache_inst = inst
+        val = cache_inst._cache.get(self.name, _sentinel)
         if val is _sentinel:
             val = self.wrapped(inst)
             (<CacheBase>inst)._cache[self.name] = val

--- a/src/propcache/_helpers_py.py
+++ b/src/propcache/_helpers_py.py
@@ -3,9 +3,18 @@
 import sys
 from collections.abc import Mapping
 from functools import cached_property
-from typing import Any, Callable, Generic, Optional, Protocol, TypeVar, Union, overload
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+    overload,
+)
 
-__all__ = ("under_cached_property", "cached_property")
+__all__ = ("CacheBase", "under_cached_property", "cached_property")
 
 
 if sys.version_info >= (3, 11):
@@ -24,10 +33,13 @@ class CacheBase:
     provides a _cache attribute that is used to store the results of
     cached properties.
 
-    Callers are responsible for creating the _cache attribute.  This is
-    done in the __init__ method of the class that inherits from
-    CachedBase.
+    Callers are responsible for calling super().__init__() in their
+    __init__() methods to ensure that the _cache attribute is
+    initialized.
     """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, Any] = {}
 
 
 class _CacheImpl(Protocol[_Cache]):
@@ -69,8 +81,3 @@ class under_cached_property(Generic[_T]):
 
     def __set__(self, inst: _CacheImpl[Any], value: _T) -> None:
         raise AttributeError("cached property is read-only")
-
-
-# For Python, the implementation of base_cached_property
-# is the same as under_cached_property
-base_cached_property = under_cached_property

--- a/src/propcache/_helpers_py.py
+++ b/src/propcache/_helpers_py.py
@@ -19,6 +19,17 @@ _T = TypeVar("_T")
 _Cache = TypeVar("_Cache", bound=Mapping[str, Any])
 
 
+class CacheBase:
+    """Base class for objects that use cached properties.  This class
+    provides a _cache attribute that is used to store the results of
+    cached properties.
+
+    Callers are responsible for creating the _cache attribute.  This is
+    done in the __init__ method of the class that inherits from
+    CachedBase.
+    """
+
+
 class _CacheImpl(Protocol[_Cache]):
     _cache: _Cache
 
@@ -58,3 +69,8 @@ class under_cached_property(Generic[_T]):
 
     def __set__(self, inst: _CacheImpl[Any], value: _T) -> None:
         raise AttributeError("cached property is read-only")
+
+
+# For Python, the implementation of base_cached_property
+# is the same as under_cached_property
+base_cached_property = under_cached_property

--- a/src/propcache/_helpers_py.py
+++ b/src/propcache/_helpers_py.py
@@ -11,7 +11,6 @@ from typing import (
     Protocol,
     TypeVar,
     Union,
-    cast,
     overload,
 )
 
@@ -49,7 +48,7 @@ class CacheBase(Generic[_Cache]):
     """
 
     def __init__(self) -> None:
-        self._cache = cast(_Cache, {})
+        self._cache: _Cache = {}  # type: ignore[assignment]
 
 
 class under_cached_property(Generic[_T]):

--- a/src/propcache/_helpers_py.py
+++ b/src/propcache/_helpers_py.py
@@ -11,10 +11,16 @@ from typing import (
     Protocol,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 
-__all__ = ("CacheBase", "under_cached_property", "cached_property")
+__all__ = (
+    "CacheBase",
+    "base_cached_property",
+    "under_cached_property",
+    "cached_property",
+)
 
 
 if sys.version_info >= (3, 11):
@@ -28,7 +34,11 @@ _T = TypeVar("_T")
 _Cache = TypeVar("_Cache", bound=Mapping[str, Any])
 
 
-class CacheBase:
+class _CacheImpl(Protocol[_Cache]):
+    _cache: _Cache
+
+
+class CacheBase(Generic[_Cache]):
     """Base class for objects that use cached properties.  This class
     provides a _cache attribute that is used to store the results of
     cached properties.
@@ -39,11 +49,7 @@ class CacheBase:
     """
 
     def __init__(self) -> None:
-        self._cache: dict[str, Any] = {}
-
-
-class _CacheImpl(Protocol[_Cache]):
-    _cache: _Cache
+        self._cache = cast(_Cache, {})
 
 
 class under_cached_property(Generic[_T]):
@@ -81,3 +87,6 @@ class under_cached_property(Generic[_T]):
 
     def __set__(self, inst: _CacheImpl[Any], value: _T) -> None:
         raise AttributeError("cached property is read-only")
+
+
+base_cached_property = under_cached_property

--- a/src/propcache/api.py
+++ b/src/propcache/api.py
@@ -1,8 +1,15 @@
 """Public API of the property caching library."""
 
-from ._helpers import cached_property, under_cached_property
+from ._helpers import (
+    CacheBase,
+    base_cached_property,
+    cached_property,
+    under_cached_property,
+)
 
 __all__ = (
+    "CacheBase",
+    "base_cached_property",
     "cached_property",
     "under_cached_property",
 )

--- a/tests/test_base_cached_property.py
+++ b/tests/test_base_cached_property.py
@@ -97,14 +97,14 @@ def test_base_cached_property_check_without_cache(
 ) -> None:
     class A:
         # Note that self._cache is intentionally missing
-        # here to verify AttributeError or SystemError is raised.
+        # here to verify AttributeError or TypeError is raised.
 
         @propcache_module.base_cached_property
         def prop(self) -> None:
             """Mock property."""
 
     a = A()
-    with pytest.raises((AttributeError, SystemError)):
+    with pytest.raises((AttributeError, TypeError)):
         _ = a.prop  # type: ignore[call-overload]
 
 

--- a/tests/test_base_cached_property.py
+++ b/tests/test_base_cached_property.py
@@ -1,0 +1,151 @@
+import sys
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict, TypeVar
+
+import pytest
+
+from propcache.api import CacheBase, base_cached_property
+
+if sys.version_info >= (3, 11):
+    from typing import assert_type
+
+_T_co = TypeVar("_T_co", covariant=True)
+
+
+class APIProtocol(Protocol):
+    def base_cached_property(
+        self, func: Callable[[Any], _T_co]
+    ) -> base_cached_property[_T_co]: ...
+
+
+def test_base_cached_property(propcache_module: APIProtocol) -> None:
+    class A(CacheBase[dict[str, int]]):
+
+        @propcache_module.base_cached_property
+        def prop(self) -> int:
+            return 1
+
+        @propcache_module.base_cached_property
+        def prop2(self) -> str:
+            return "foo"
+
+    a = A()
+    if sys.version_info >= (3, 11):
+        assert_type(a.prop, int)
+    assert a.prop == 1
+    if sys.version_info >= (3, 11):
+        assert_type(a.prop2, str)
+    assert a.prop2 == "foo"
+
+
+def test_base_cached_property_typeddict(propcache_module: APIProtocol) -> None:
+    """Test static typing passes with TypedDict."""
+
+    class _Cache(TypedDict, total=False):
+        prop: int
+        prop2: str
+
+    class A(CacheBase[_Cache]):
+
+        @propcache_module.base_cached_property
+        def prop(self) -> int:
+            return 1
+
+        @propcache_module.base_cached_property
+        def prop2(self) -> str:
+            return "foo"
+
+    a = A()
+    if sys.version_info >= (3, 11):
+        assert_type(a.prop, int)
+    assert a.prop == 1
+    if sys.version_info >= (3, 11):
+        assert_type(a.prop2, str)
+    assert a.prop2 == "foo"
+
+
+def test_base_cached_property_assignment(propcache_module: APIProtocol) -> None:
+    class A(CacheBase[dict[str, Any]]):
+
+        @propcache_module.base_cached_property
+        def prop(self) -> None:
+            """Mock property."""
+
+    a = A()
+
+    with pytest.raises(AttributeError):
+        a.prop = 123  # type: ignore[assignment]
+
+
+def test_base_cached_property_without_cache(propcache_module: APIProtocol) -> None:
+    class A(CacheBase[dict[str, int]]):
+
+        @propcache_module.base_cached_property
+        def prop(self) -> None:
+            """Mock property."""
+
+    a = A()
+
+    with pytest.raises(AttributeError):
+        a.prop = 123  # type: ignore[assignment]
+
+
+def test_base_cached_property_check_without_cache(
+    propcache_module: APIProtocol,
+) -> None:
+    class A:
+        # Note that self._cache is intentionally missing
+        # here to verify AttributeError or SystemError is raised.
+
+        @propcache_module.base_cached_property
+        def prop(self) -> None:
+            """Mock property."""
+
+    a = A()
+    with pytest.raises((AttributeError, SystemError)):
+        _ = a.prop  # type: ignore[call-overload]
+
+
+def test_base_cached_property_caching(propcache_module: APIProtocol) -> None:
+    class A(CacheBase[dict[str, int]]):
+
+        @propcache_module.base_cached_property
+        def prop(self) -> int:
+            """Docstring."""
+            return 1
+
+    a = A()
+    assert a.prop == 1
+
+
+def test_base_cached_property_class_docstring(propcache_module: APIProtocol) -> None:
+    class A(CacheBase[dict[str, int]]):
+        def __init__(self) -> None:
+            """Init."""
+
+        @propcache_module.base_cached_property
+        def prop(self) -> None:
+            """Docstring."""
+
+    if TYPE_CHECKING:
+        # At type checking, the fixture doesn't represent the real module, so
+        # we use the global-level imported module to verify the isinstance() check here
+        # matches the behaviour users would see in real code.
+        assert isinstance(A.prop, base_cached_property)
+    else:
+        assert isinstance(A.prop, propcache_module.base_cached_property)
+    assert "Docstring." == A.prop.__doc__
+
+
+def test_ensured_wrapped_function_is_accessible(propcache_module: APIProtocol) -> None:
+    """Test that the wrapped function can be accessed from python."""
+
+    class A(CacheBase[dict[str, int]]):
+
+        @propcache_module.base_cached_property
+        def prop(self) -> int:
+            """Docstring."""
+            return 1
+
+    a = A()
+    assert A.prop.wrapped(a) == 1

--- a/tests/test_base_cached_property.py
+++ b/tests/test_base_cached_property.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol, TypedDict, TypeVar

--- a/tests/test_base_cached_property.py
+++ b/tests/test_base_cached_property.py
@@ -21,7 +21,7 @@ class APIProtocol(Protocol):
 
 
 def test_base_cached_property(propcache_module: APIProtocol) -> None:
-    class A(CacheBase[dict[str, int]]):
+    class A(CacheBase):  # type: ignore[type-arg]
 
         @propcache_module.base_cached_property
         def prop(self) -> int:
@@ -47,7 +47,7 @@ def test_base_cached_property_typeddict(propcache_module: APIProtocol) -> None:
         prop: int
         prop2: str
 
-    class A(CacheBase[_Cache]):
+    class A(CacheBase):  # type: ignore[type-arg]
 
         @propcache_module.base_cached_property
         def prop(self) -> int:
@@ -67,7 +67,7 @@ def test_base_cached_property_typeddict(propcache_module: APIProtocol) -> None:
 
 
 def test_base_cached_property_assignment(propcache_module: APIProtocol) -> None:
-    class A(CacheBase[dict[str, Any]]):
+    class A(CacheBase):  # type: ignore[type-arg]
 
         @propcache_module.base_cached_property
         def prop(self) -> None:
@@ -80,7 +80,7 @@ def test_base_cached_property_assignment(propcache_module: APIProtocol) -> None:
 
 
 def test_base_cached_property_without_cache(propcache_module: APIProtocol) -> None:
-    class A(CacheBase[dict[str, int]]):
+    class A(CacheBase):  # type: ignore[type-arg]
 
         @propcache_module.base_cached_property
         def prop(self) -> None:
@@ -93,7 +93,7 @@ def test_base_cached_property_without_cache(propcache_module: APIProtocol) -> No
 
 
 def test_base_cached_property_caching(propcache_module: APIProtocol) -> None:
-    class A(CacheBase[dict[str, int]]):
+    class A(CacheBase):  # type: ignore[type-arg]
 
         @propcache_module.base_cached_property
         def prop(self) -> int:
@@ -105,7 +105,7 @@ def test_base_cached_property_caching(propcache_module: APIProtocol) -> None:
 
 
 def test_base_cached_property_class_docstring(propcache_module: APIProtocol) -> None:
-    class A(CacheBase[dict[str, int]]):
+    class A(CacheBase):  # type: ignore[type-arg]
         def __init__(self) -> None:
             """Init."""
 
@@ -126,7 +126,7 @@ def test_base_cached_property_class_docstring(propcache_module: APIProtocol) -> 
 def test_ensured_wrapped_function_is_accessible(propcache_module: APIProtocol) -> None:
     """Test that the wrapped function can be accessed from python."""
 
-    class A(CacheBase[dict[str, int]]):
+    class A(CacheBase):  # type: ignore[type-arg]
 
         @propcache_module.base_cached_property
         def prop(self) -> int:

--- a/tests/test_base_cached_property.py
+++ b/tests/test_base_cached_property.py
@@ -90,22 +90,6 @@ def test_base_cached_property_without_cache(propcache_module: APIProtocol) -> No
         a.prop = 123  # type: ignore[assignment]
 
 
-def test_base_cached_property_check_without_cache(
-    propcache_module: APIProtocol,
-) -> None:
-    class A:
-        # Note that self._cache is intentionally missing
-        # here to verify AttributeError or SystemError is raised.
-
-        @propcache_module.base_cached_property
-        def prop(self) -> None:
-            """Mock property."""
-
-    a = A()
-    with pytest.raises((AttributeError, SystemError)):
-        _ = a.prop  # type: ignore[call-overload]
-
-
 def test_base_cached_property_caching(propcache_module: APIProtocol) -> None:
     class A(CacheBase[dict[str, int]]):
 

--- a/tests/test_base_cached_property.py
+++ b/tests/test_base_cached_property.py
@@ -92,6 +92,22 @@ def test_base_cached_property_without_cache(propcache_module: APIProtocol) -> No
         a.prop = 123  # type: ignore[assignment]
 
 
+def test_base_cached_property_check_without_cache(
+    propcache_module: APIProtocol,
+) -> None:
+    class A:
+        # Note that self._cache is intentionally missing
+        # here to verify AttributeError or SystemError is raised.
+
+        @propcache_module.base_cached_property
+        def prop(self) -> None:
+            """Mock property."""
+
+    a = A()
+    with pytest.raises((AttributeError, SystemError)):
+        _ = a.prop  # type: ignore[call-overload]
+
+
 def test_base_cached_property_caching(propcache_module: APIProtocol) -> None:
     class A(CacheBase):  # type: ignore[type-arg]
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -18,7 +18,7 @@ from propcache.api import (
 def test_base_cached_property_cache_hit(benchmark: "BenchmarkFixture") -> None:
     """Benchmark for base_cached_property cache hit."""
 
-    class Test(CacheBase):
+    class Test(CacheBase[dict[str, int]]):
         def __init__(self) -> None:
             super().__init__()
             self._cache["prop"] = 42
@@ -79,7 +79,7 @@ def test_cached_property_cache_hit(benchmark: "BenchmarkFixture") -> None:
 def test_base_cached_property_cache_miss(benchmark: "BenchmarkFixture") -> None:
     """Benchmark for under_cached_property cache miss."""
 
-    class Test(CacheBase):
+    class Test(CacheBase[dict[str, int]]):
 
         @base_cached_property
         def prop(self) -> int:

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -18,7 +18,7 @@ from propcache.api import (
 def test_base_cached_property_cache_hit(benchmark: "BenchmarkFixture") -> None:
     """Benchmark for base_cached_property cache hit."""
 
-    class Test(CacheBase[dict[str, int]]):
+    class Test(CacheBase):  # type: ignore[type-arg]
         def __init__(self) -> None:
             super().__init__()
             self._cache["prop"] = 42
@@ -79,7 +79,7 @@ def test_cached_property_cache_hit(benchmark: "BenchmarkFixture") -> None:
 def test_base_cached_property_cache_miss(benchmark: "BenchmarkFixture") -> None:
     """Benchmark for under_cached_property cache miss."""
 
-    class Test(CacheBase[dict[str, int]]):
+    class Test(CacheBase):  # type: ignore[type-arg]
 
         @base_cached_property
         def prop(self) -> int:

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -20,7 +20,8 @@ def test_base_cached_property_cache_hit(benchmark: "BenchmarkFixture") -> None:
 
     class Test(CacheBase):
         def __init__(self) -> None:
-            self._cache = {"prop": 42}
+            super().__init__()
+            self._cache["prop"] = 42
 
         @base_cached_property
         def prop(self) -> int:
@@ -79,8 +80,6 @@ def test_base_cached_property_cache_miss(benchmark: "BenchmarkFixture") -> None:
     """Benchmark for under_cached_property cache miss."""
 
     class Test(CacheBase):
-        def __init__(self) -> None:
-            self._cache: dict[str, int] = {}
 
         @base_cached_property
         def prop(self) -> int:

--- a/tests/test_under_cached_property.py
+++ b/tests/test_under_cached_property.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol, TypedDict, TypeVar


### PR DESCRIPTION
Experiment to see if avoiding the `__Pyx_PyObject_GetAttrStr` and `PyDict_CheckExact` make any difference