### PR TITLE
Only enable line tracing when building with Cython tracing

### DIFF
--- a/CHANGES/118.packaging.rst
+++ b/CHANGES/118.packaging.rst
@@ -1,0 +1,5 @@
+Made Cython line tracing opt-in via the ``with-cython-tracing`` build config setting -- by :user:`bdraco`.
+
+Previously, line tracing was enabled by default in :file:`pyproject.toml`, which caused build issues for some users and made wheels nearly twice as slow.
+
+Now line tracing is only enabled when explicitly requested via ``pip install . --config-setting=with-cython-tracing=true`` or by setting the ``PROPCACHE_CYTHON_TRACING`` environment variable.

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -293,7 +293,7 @@ def maybe_prebuild_c_extensions(
     with build_dir_ctx:
         config = _get_local_cython_config()
 
-        cythonize_args = _make_cythonize_cli_args_from_config(config)
+        cythonize_args = _make_cythonize_cli_args_from_config(config, cython_line_tracing_requested)
         with _patched_cython_env(config['env'], cython_line_tracing_requested):
             _cythonize_cli_cmd(cythonize_args)  # type: ignore[no-untyped-call]
         with patched_distutils_cmd_install():

--- a/packaging/pep517_backend/_cython_configuration.py
+++ b/packaging/pep517_backend/_cython_configuration.py
@@ -18,7 +18,7 @@ from ._transformers import get_cli_kwargs_from_config, get_enabled_cli_flags_fro
 class Config(TypedDict):
     env: dict[str, str]
     flags: dict[str, bool]
-    kwargs: dict[str, str]
+    kwargs: dict[str, str | dict[str, str]]
     src: list[str]
 
 
@@ -79,11 +79,25 @@ def get_local_cython_config() -> Config:
     return config_mapping['tool']['local']['cythonize']  # type: ignore[no-any-return]
 
 
-def make_cythonize_cli_args_from_config(config: Config) -> list[str]:
+def _configure_cython_line_tracing(config_kwargs: dict[str, str | dict[str, str]], cython_line_tracing_requested: bool) -> None:
+    """Configure Cython line tracing directives if requested."""
+    # If line tracing is requested, add it to the directives
+    if cython_line_tracing_requested:
+        directives = config_kwargs.setdefault('directive', {})
+        assert isinstance(directives, dict)  # Type narrowing for mypy
+        directives['linetrace'] = 'True'
+        directives['profile'] = 'True'
+
+
+def make_cythonize_cli_args_from_config(config: Config, cython_line_tracing_requested: bool = False) -> list[str]:
     py_ver_arg = f'-{_python_version_tuple.major!s}'
 
     cli_flags = get_enabled_cli_flags_from_config(config['flags'])
-    cli_kwargs = get_cli_kwargs_from_config(config['kwargs'])
+    config_kwargs = config['kwargs']
+
+    _configure_cython_line_tracing(config_kwargs, cython_line_tracing_requested)
+
+    cli_kwargs = get_cli_kwargs_from_config(config_kwargs)
 
     return cli_flags + [py_ver_arg] + cli_kwargs + ['--'] + config['src']
 

--- a/packaging/pep517_backend/_cython_configuration.py
+++ b/packaging/pep517_backend/_cython_configuration.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from sys import version_info as _python_version_tuple
-from typing import TypedDict
+from typing import TypedDict, Union
 
 from expandvars import expandvars
 

--- a/packaging/pep517_backend/_cython_configuration.py
+++ b/packaging/pep517_backend/_cython_configuration.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from sys import version_info as _python_version_tuple
-from typing import TypedDict, Union
+from typing import TypedDict
 
 from expandvars import expandvars
 

--- a/packaging/pep517_backend/_transformers.py
+++ b/packaging/pep517_backend/_transformers.py
@@ -18,7 +18,7 @@ def _emit_opt_pairs(opt_pair: tuple[str, Union[dict[str, str], str]]) -> Iterato
 
 
 def get_cli_kwargs_from_config(
-    kwargs_map: dict[str, str | dict[str, str]],
+    kwargs_map: dict[str, Union[str, dict[str, str]]],
 ) -> list[str]:
     """Make a list of options with values from config."""
     return list(chain.from_iterable(map(_emit_opt_pairs, kwargs_map.items())))

--- a/packaging/pep517_backend/_transformers.py
+++ b/packaging/pep517_backend/_transformers.py
@@ -17,7 +17,9 @@ def _emit_opt_pairs(opt_pair: tuple[str, Union[dict[str, str], str]]) -> Iterato
     yield from ("=".join(map(str, (flag_opt,) + pair)) for pair in sub_pairs)
 
 
-def get_cli_kwargs_from_config(kwargs_map: dict[str, str]) -> list[str]:
+def get_cli_kwargs_from_config(
+    kwargs_map: dict[str, str | dict[str, str]],
+) -> list[str]:
     """Make a list of options with values from config."""
     return list(chain.from_iterable(map(_emit_opt_pairs, kwargs_map.items())))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ keep-going = false
 # https://cython.rtfd.io/en/latest/src/userguide/source_files_and_compilation.html#compiler-directives
 embedsignature = "True"
 emit_code_comments = "True"
-linetrace = "True"  # Implies `profile=True`
 
 [tool.local.cythonize.kwargs.compile-time-env]
 # This section can contain compile time env vars


### PR DESCRIPTION
This PR modifies the build backend to dynamically enable Cython line tracing only when explicitly requested via the `with-cython-tracing=true` config setting. Previously, having `linetrace = "True"` in pyproject.toml was causing build issues for users (https://github.com/aio-libs/frozenlist/issues/658) and makes our production wheels almost half as fast.

Now, line tracing is opt-in:
- Regular builds: `pip install .` (no line tracing)
- Tracing builds: `pip install . --config-setting=with-cython-tracing=true` (enables line tracing)

When tracing is requested, the build backend automatically adds the `linetrace=True` and `profile=True` Cython directives and sets the appropriate C compiler flags.

<!-- Outline any notable behaviour for the end users. -->

- Regular users will no longer encounter build issues related to line tracing being enabled by default
- Developers who need line tracing must now explicitly enable it using `--config-setting=with-cython-tracing=true`
- The `YARL_CYTHON_TRACING` environment variable can also be used as an alternative to the config setting

<!-- Are there any issues opened that will be resolved by merging this change? --> <!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
