### PR TITLE
Pin cffi for <3.14 in tests to fix CI

### DIFF
--- a/requirements/codspeed.txt
+++ b/requirements/codspeed.txt
@@ -1,2 +1,3 @@
 -r test.txt
+cffi<2.0.0;python_version<"3.14"
 pytest-codspeed==4.0.0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Alternative approach to #147.
Cffi v2 doesn't support free threading on Python 3.13. Pin cffi to `<2.0` for `<3.14`.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
