### PR TITLE
Fix codspeed v4 in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -478,6 +478,7 @@ jobs:
       with:
         token: ${{ secrets.CODSPEED_TOKEN }}
         run: python -Im pytest --no-cov -vvvvv --codspeed
+        mode: instrumentation
 
   test-summary:
     name: Test matrix status


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

mode: instrumentation was missing causing the CI to fail benchmarks

