### PR TITLE
Fix wheel builds for odd arches

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -526,6 +526,7 @@ jobs:
           qemu: armv7l
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
+      os: ubuntu-latest
       qemu: ${{ matrix.qemu }}
       tag: ${{ matrix.tag }}
       wheel-tags-to-skip: >-


### PR DESCRIPTION
commit 5615954 updated the build-wheels-for-tested-arches matrix to pass ubuntu-latest, windows-latest, etc., but forgot to update the build-wheels-for-odd-archs job
