### PR TITLE
Fix changelog format to match release CI expectations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ Changelog
 
 .. towncrier release notes start
 
-v0.4.0
-======
+0.4.0
+=====
 
 *(2025-10-04)*
 


### PR DESCRIPTION
No `v` is expected in the CI