### PR TITLE
Loosen the Cython build dependency specifier to >= 3.2.0

### DIFF
--- a/CHANGES/184.packaging.rst
+++ b/CHANGES/184.packaging.rst
@@ -1,1 +1,3 @@
-Update Cython to version 3.2.3 -- by :user:`jameshilliard`.
+Changed the Cython build dependency from ``~= 3.2.0`` to ``>= 3.2.0``,
+removing the upper version bound to avoid conflicts for downstream packagers
+-- by :user:`jameshilliard` and :user:`gundalow`.

--- a/CHANGES/184.packaging.rst
+++ b/CHANGES/184.packaging.rst
@@ -1,3 +1,5 @@
-Changed the Cython build dependency from ``~= 3.2.0`` to ``>= 3.2.0``,
+Changed the Cython build dependency from ``~= 3.1.0`` to ``>= 3.2.0``,
 removing the upper version bound to avoid conflicts for downstream packagers
 -- by :user:`jameshilliard` and :user:`gundalow`.
+
+The upstream Cython version is pinned to 3.2.4 in the CI/CD environment.

--- a/CHANGES/188.packaging.rst
+++ b/CHANGES/188.packaging.rst
@@ -1,0 +1,1 @@
+184.packaging.rst

--- a/CHANGES/214.packaging.rst
+++ b/CHANGES/214.packaging.rst
@@ -1,3 +1,1 @@
-Changed the Cython build dependency from ``~= 3.2.0`` to ``>= 3.2.0``,
-removing the upper version bound to avoid conflicts for downstream packagers
--- by :user:`gundalow`.
+184.packaging.rst

--- a/CHANGES/214.packaging.rst
+++ b/CHANGES/214.packaging.rst
@@ -1,0 +1,3 @@
+Changed the Cython build dependency from ``~= 3.2.0`` to ``>= 3.2.0``,
+removing the upper version bound to avoid conflicts for downstream packagers
+-- by :user:`gundalow`.

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -376,7 +376,7 @@ def get_requires_for_build_wheel(
     if is_pure_python_build:
         c_ext_build_deps = []
     else:
-        c_ext_build_deps = ['Cython ~= 3.2.0']
+        c_ext_build_deps = ['Cython >= 3.2.0']
 
     return _setuptools_get_requires_for_build_wheel(
         config_settings=config_settings,


### PR DESCRIPTION
## What do these changes do?

Changed the Cython build dependency specifier in `get_requires_for_build_wheel()` from `~= 3.2.0` (`>= 3.2.0, < 3.3.0`) to `>= 3.2.0`, removing the upper version bound.

The pinned version in `requirements/cython.txt` (`== 3.2.4`) is unchanged and continues to control the exact Cython version used in CI and cibuildwheel. This change only affects downstream packagers who disable build isolation or set their own constraints.


## Are there changes in behavior for the user?

No change for propcache's own builds. Downstream packagers (e.g., distro packagers) who supply their own Cython >= 3.3.0 will no longer hit a dependency resolution conflict.

## Related issue number

Follows guidance from:

- https://github.com/aio-libs/propcache/pull/84#discussion_r1958404396 — @webknjaz recommends loose specifiers in the build backend with pinned constraints
- https://github.com/aio-libs/propcache/pull/184 — @webknjaz notes the upper bound is causing problems for downstreams


## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist: N/A
- [X] Documentation reflects the changes

## Changelog

<img width="898" height="658" alt="image" src="https://github.com/user-attachments/assets/33736b19-75fe-4433-a50f-551e7980967a" />


