### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -202,7 +202,6 @@ jobs:
         - 3.11
         - >-
           3.10
-        - 3.9
         no-extensions: ['', 'Y']
         os:
         - ubuntu-latest
@@ -218,15 +217,9 @@ jobs:
         - os: windows-11-arm
           no-extensions: Y
         - os: windows-11-arm
-          pyver: '3.9'  # not supported by setup-python action
-        - os: windows-11-arm
           pyver: '3.10'  # not supported by setup-python action
         include:
         - pyver: pypy-3.10
-          no-extensions: Y
-          experimental: false
-          os: ubuntu-latest
-        - pyver: pypy-3.9
           no-extensions: Y
           experimental: false
           os: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
   rev: 'v3.21.2'
   hooks:
   - id: pyupgrade
-    args: ['--py39-plus']
+    args: ['--py310-plus']
 - repo: https://github.com/PyCQA/flake8
   rev: '7.3.0'
   hooks:

--- a/CHANGES/216.breaking.rst
+++ b/CHANGES/216.breaking.rst
@@ -1,0 +1,1 @@
+Dropped support for Python 3.9 as it has reached end of life.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 propcache
 =========
 
-The module provides a fast implementation of cached properties for Python 3.9+.
+The module provides a fast implementation of cached properties for Python 3.10+.
 
 .. image:: https://github.com/aio-libs/propcache/actions/workflows/ci-cd.yml/badge.svg
   :target: https://github.com/aio-libs/propcache/actions?query=workflow%3ACI

--- a/packaging/pep517_backend/_transformers.py
+++ b/packaging/pep517_backend/_transformers.py
@@ -3,7 +3,6 @@
 from collections.abc import Iterable, Iterator, Mapping
 from itertools import chain
 from re import sub as _substitute_with_regexp
-from typing import Union
 
 
 def _emit_opt_pairs(opt_pair: tuple[str, dict[str, str] | str]) -> Iterator[str]:

--- a/packaging/pep517_backend/_transformers.py
+++ b/packaging/pep517_backend/_transformers.py
@@ -6,7 +6,7 @@ from re import sub as _substitute_with_regexp
 from typing import Union
 
 
-def _emit_opt_pairs(opt_pair: tuple[str, Union[dict[str, str], str]]) -> Iterator[str]:
+def _emit_opt_pairs(opt_pair: tuple[str, dict[str, str] | str]) -> Iterator[str]:
     flag, flag_value = opt_pair
     flag_opt = f"--{flag!s}"
     if isinstance(flag_value, dict):
@@ -18,7 +18,7 @@ def _emit_opt_pairs(opt_pair: tuple[str, Union[dict[str, str], str]]) -> Iterato
 
 
 def get_cli_kwargs_from_config(
-    kwargs_map: dict[str, Union[str, dict[str, str]]],
+    kwargs_map: dict[str, str | dict[str, str]],
 ) -> list[str]:
     """Make a list of options with values from config."""
     return list(chain.from_iterable(map(_emit_opt_pairs, kwargs_map.items())))

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ classifiers =
   Programming Language :: Cython
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3.12
@@ -53,7 +52,7 @@ keywords =
   propcache
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.10
 # Ref:
 # https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#using-a-src-layout
 # (`src/` layout)

--- a/src/propcache/_helpers_py.py
+++ b/src/propcache/_helpers_py.py
@@ -1,10 +1,9 @@
 """Various helper functions."""
 
 import sys
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from functools import cached_property
-from typing import Any, Generic, Optional, Protocol, TypeVar, Union, overload
-from collections.abc import Callable
+from typing import Any, Generic, Protocol, TypeVar, overload
 
 __all__ = ("under_cached_property", "cached_property")
 

--- a/src/propcache/_helpers_py.py
+++ b/src/propcache/_helpers_py.py
@@ -3,7 +3,8 @@
 import sys
 from collections.abc import Mapping
 from functools import cached_property
-from typing import Any, Callable, Generic, Optional, Protocol, TypeVar, Union, overload
+from typing import Any, Generic, Optional, Protocol, TypeVar, Union, overload
+from collections.abc import Callable
 
 __all__ = ("under_cached_property", "cached_property")
 
@@ -39,16 +40,16 @@ class under_cached_property(Generic[_T]):
         self.name = wrapped.__name__
 
     @overload
-    def __get__(self, inst: None, owner: Optional[type[object]] = None) -> Self: ...
+    def __get__(self, inst: None, owner: type[object] | None = None) -> Self: ...
 
     @overload
     def __get__(
-        self, inst: _CacheImpl[Any], owner: Optional[type[object]] = None
+        self, inst: _CacheImpl[Any], owner: type[object] | None = None
     ) -> _T: ...
 
     def __get__(
-        self, inst: Optional[_CacheImpl[Any]], owner: Optional[type[object]] = None
-    ) -> Union[_T, Self]:
+        self, inst: _CacheImpl[Any] | None, owner: type[object] | None = None
+    ) -> _T | Self:
         if inst is None:
             return self
         try:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Removes Python 3.9 from the CI matrix, classifiers, `python_requires`, and the pyupgrade target; bumps the PyPy entry to pypy-3.10. Mirrors the equivalent change in multidict (aio-libs/multdict#1316).

## Are there changes in behavior for the user?

Users on Python 3.9 will no longer receive new releases; the minimum supported version is now Python 3.10.

## Related issue number

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes