### PR TITLE
Discussion should be in GH Org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -19,7 +19,7 @@ contact_links:
 - name: >-
     [🎉 NEW 🎉]
     🤷💻🤦 GitHub Discussions
-  url: https://github.com/aio-libs/propcache/discussions
+  url: https://github.com/orgs/aio-libs/discussions
   about: >-
     Please ask typical Q&A in the Discussions tab or on StackOverflow
 - name: 🤷💻🤦 StackOverflow

--- a/CHANGES/217.doc.rst
+++ b/CHANGES/217.doc.rst
@@ -1,3 +1,3 @@
 Updated discussion links from the defunct Google Groups forum to
-GitHub Discussions in the org-wide aio-libs space
+the ``aio-libs`` org-wide GitHub Discussions
 -- by :user:`gundalow`.

--- a/CHANGES/217.doc.rst
+++ b/CHANGES/217.doc.rst
@@ -1,0 +1,3 @@
+Updated discussion links from the defunct Google Groups forum to
+GitHub Discussions in the org-wide aio-libs space
+-- by :user:`gundalow`.

--- a/CHANGES/217.doc.rst
+++ b/CHANGES/217.doc.rst
@@ -1,0 +1,3 @@
+Updated discussion links from the defunct Google Groups forum to
+GitHub Discussions
+-- by :user:`gundalow`.

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ or have some suggestion in order to improve the library.
 Discussion list
 ---------------
 
-*aio-libs* google group: https://groups.google.com/forum/#!forum/aio-libs
+*aio-libs* GitHub Discussions: https://github.com/orgs/aio-libs/discussions
 
 Feel free to post your questions and ideas here.
 

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ or have some suggestion in order to improve the library.
 Discussion list
 ---------------
 
-*aio-libs* google group: https://groups.google.com/forum/#!forum/aio-libs
+*aio-libs* GitHub Discussions: https://github.com/aio-libs/propcache/discussions
 
 Feel free to post your questions and ideas here.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ or have some suggestion in order to improve the library.
 Discussion list
 ---------------
 
-*aio-libs* google group: https://groups.google.com/forum/#!forum/aio-libs
+*aio-libs* GitHub Discussions: https://github.com/orgs/aio-libs/discussions
 
 Feel free to post your questions and ideas here.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ or have some suggestion in order to improve the library.
 Discussion list
 ---------------
 
-*aio-libs* google group: https://groups.google.com/forum/#!forum/aio-libs
+*aio-libs* GitHub Discussions: https://github.com/aio-libs/propcache/discussions
 
 Feel free to post your questions and ideas here.
 


### PR DESCRIPTION

## What do these changes do?

The Google Group has been archived, GitHub Discussions are not enabled in this repo.

Just a few small docs updates I noticed when looking round the repo

## Are there changes in behavior for the user?

N/A

## Related issue number

N/A

## Checklist

- [ ] I think the code is well written: N/A
- [ ] Unit tests for the changes exist: N/A
- [X] Documentation reflects the changes
