### PR TITLE
Make wheel builds reproducible

### DIFF
--- a/CHANGES/218.packaging.rst
+++ b/CHANGES/218.packaging.rst
@@ -1,0 +1,22 @@
+The :pep:`517` build backend now supports a new ``build-inplace``
+config setting (and ``PROPCACHE_BUILD_INPLACE`` environment variable)
+for controlling whether to build the project in-tree or in a
+temporary directory. It only affects wheels and is set up to build
+in a temporary directory by default. It does not affect editable
+wheel builds, they will keep being built in-tree regardless.
+
+Here's an example of using this setting:
+
+.. code-block:: console
+
+   $ python -m build --config-setting=build-inplace=true
+
+Additionally, when building wheels in an automatically created
+temporary directory, the build backend now normalizes the
+respective file system path to a deterministic source checkout
+directory by injecting the ``-ffile-prefix-map`` compiler option
+into the ``CFLAGS`` environment variable, as suggested by known
+`reproducible build practices
+<https://reproducible-builds.org/docs/build-path/>`__.
+
+The effect is that downstreams will get reproducible build results.

--- a/CHANGES/218.packaging.rst
+++ b/CHANGES/218.packaging.rst
@@ -3,7 +3,7 @@ config setting (and ``PROPCACHE_BUILD_INPLACE`` environment variable)
 for controlling whether to build the project in-tree or in a
 temporary directory. It only affects wheels and is set up to build
 in a temporary directory by default. It does not affect editable
-wheel builds, they will keep being built in-tree regardless.
+wheel builds; they will keep being built in-tree regardless.
 
 Here's an example of using this setting:
 

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -77,6 +77,12 @@ CYTHON_TRACING_ENV_VAR = 'PROPCACHE_CYTHON_TRACING'
 PURE_PYTHON_CONFIG_SETTING = 'pure-python'
 """Config setting name toggle that is used to opt out of making C-exts."""
 
+BUILD_INPLACE_CONFIG_SETTING = 'build-inplace'
+"""Config setting name toggle for building C-exts in-place."""
+
+BUILD_INPLACE_ENV_VAR = 'PROPCACHE_BUILD_INPLACE'
+"""Environment variable name toggle for building C-exts in-place."""
+
 PURE_PYTHON_ENV_VAR = 'PROPCACHE_NO_EXTENSIONS'
 """Environment variable name toggle used to opt out of making C-exts."""
 
@@ -131,6 +137,19 @@ def _include_cython_line_tracing(
         config_settings,
         CYTHON_TRACING_CONFIG_SETTING,
         CYTHON_TRACING_ENV_VAR,
+        default=default,
+    )
+
+
+def _build_inplace(
+        config_settings: _ConfigDict | None = None,
+        *,
+        default: bool = False,
+) -> bool:
+    return _get_setting_value(
+        config_settings,
+        BUILD_INPLACE_CONFIG_SETTING,
+        BUILD_INPLACE_ENV_VAR,
         default=default,
     )
 
@@ -217,7 +236,7 @@ def _exclude_dir_path(
 
 
 @contextmanager
-def _in_temporary_directory(src_dir: Path) -> t.Iterator[None]:
+def _in_temporary_directory(src_dir: Path) -> t.Iterator[Path]:
     with TemporaryDirectory(prefix='.tmp-propcache-pep517-') as tmp_dir:
         tmp_dir_path = Path(tmp_dir)
         root_tmp_dir_path = tmp_dir_path.parent
@@ -232,7 +251,7 @@ def _in_temporary_directory(src_dir: Path) -> t.Iterator[None]:
                 symlinks=True,
             )
             os.chdir(tmp_src_dir)
-            yield
+            yield tmp_src_dir
 
 
 @contextmanager
@@ -275,6 +294,10 @@ def maybe_prebuild_c_extensions(
 
     print("**********************", file=_standard_error_stream)
     print("* Accelerated build *", file=_standard_error_stream)
+    print(
+        f'* Build location: {"in-tree" if build_inplace else "tmp dir"} *',
+        file=_standard_error_stream,
+    )
     print("**********************", file=_standard_error_stream)
     if not IS_CPYTHON:
         _warn_that(
@@ -285,15 +308,21 @@ def maybe_prebuild_c_extensions(
             stacklevel=999,
         )
 
+    original_src_dir = Path.cwd().resolve()
     build_dir_ctx = (
         nullcontext() if build_inplace
-        else _in_temporary_directory(src_dir=Path.cwd().resolve())
+        else _in_temporary_directory(src_dir=original_src_dir)
     )
-    with build_dir_ctx:
+    with build_dir_ctx as tmp_build_dir:
         config = _get_local_cython_config()
 
         cythonize_args = _make_cythonize_cli_args_from_config(config, cython_line_tracing_requested)
-        with _patched_cython_env(config['env'], cython_line_tracing_requested):
+        with _patched_cython_env(
+                config['env'],
+                cython_line_tracing_requested,
+                original_source_directory=original_src_dir,
+                temporary_build_directory=tmp_build_dir,
+        ):
             _cythonize_cli_cmd(cythonize_args)  # type: ignore[no-untyped-call]
         with patched_distutils_cmd_install():
             with patched_dist_has_ext_modules():
@@ -317,7 +346,7 @@ def build_wheel(
     """
     with maybe_prebuild_c_extensions(
             line_trace_cython_when_unset=False,
-            build_inplace=False,
+            build_inplace=_build_inplace(config_settings, default=False),
             config_settings=config_settings,
     ):
         return _setuptools_build_wheel(
@@ -342,9 +371,17 @@ def build_editable(
     :param metadata_directory: :file:`.dist-info` directory path.
 
     """
+    mandatory_build_inplace = True
+    if not _build_inplace(config_settings, default=mandatory_build_inplace):
+        _warn_that(
+            'Editable builds require C-extensions to be produced in-tree',
+            RuntimeWarning,
+            stacklevel=999,
+        )
+
     with maybe_prebuild_c_extensions(
             line_trace_cython_when_unset=True,
-            build_inplace=True,
+            build_inplace=mandatory_build_inplace,
             config_settings=config_settings,
     ):
         return _setuptools_build_editable(

--- a/packaging/pep517_backend/_cython_configuration.py
+++ b/packaging/pep517_backend/_cython_configuration.py
@@ -103,7 +103,13 @@ def make_cythonize_cli_args_from_config(config: Config, cython_line_tracing_requ
 
 
 @contextmanager
-def patched_env(env: dict[str, str], cython_line_tracing_requested: bool) -> Iterator[None]:
+def patched_env(
+    env: dict[str, str],
+    cython_line_tracing_requested: bool,
+    *,
+    original_source_directory: Path | None = None,
+    temporary_build_directory: Path | None = None,
+) -> Iterator[None]:
     """Temporary set given env vars.
 
     :param env: tmp env vars to set
@@ -115,11 +121,20 @@ def patched_env(env: dict[str, str], cython_line_tracing_requested: bool) -> Ite
     expanded_env = {name: expandvars(var_val) for name, var_val in env.items()}  # type: ignore[no-untyped-call]
     os.environ.update(expanded_env)
 
+    extra_cflags: list[str] = []
     if cython_line_tracing_requested:
-        os.environ['CFLAGS'] = ' '.join((
-            os.getenv('CFLAGS', ''),
-            '-DCYTHON_TRACE_NOGIL=1',  # Implies CYTHON_TRACE=1
-        )).strip()
+        extra_cflags.append('-DCYTHON_TRACE_NOGIL=1')  # Implies CYTHON_TRACE=1
+    # When building in a temporary directory, rewrite the random tmp dir
+    # path back to the original source directory so the compiled artifacts
+    # are reproducible. Ref: https://github.com/aio-libs/propcache/issues/68
+    if temporary_build_directory is not None:
+        extra_cflags.append(
+            f'-ffile-prefix-map={temporary_build_directory!s}={original_source_directory!s}',
+        )
+    if extra_cflags:
+        os.environ['CFLAGS'] = ' '.join(
+            (os.getenv('CFLAGS', ''), *extra_cflags),
+        ).strip()
     try:
         yield
     finally:

--- a/packaging/pep517_backend/_cython_configuration.py
+++ b/packaging/pep517_backend/_cython_configuration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -126,8 +127,11 @@ def patched_env(
         extra_cflags.append('-DCYTHON_TRACE_NOGIL=1')  # Implies CYTHON_TRACE=1
     # When building in a temporary directory, rewrite the random tmp dir
     # path back to the original source directory so the compiled artifacts
-    # are reproducible. Ref: https://github.com/aio-libs/propcache/issues/68
-    if temporary_build_directory is not None:
+    # are reproducible. `-ffile-prefix-map` is a GCC/Clang flag and is not
+    # understood by MSVC, so skip it on Windows.
+    # Ref: https://github.com/aio-libs/propcache/issues/68
+    if temporary_build_directory is not None and sys.platform != 'win32':
+        assert original_source_directory is not None
         extra_cflags.append(
             f'-ffile-prefix-map={temporary_build_directory!s}={original_source_directory!s}',
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Ports the two yarl reproducibility fixes (aio-libs/yarl#1590, aio-libs/yarl#1591) to propcache; addresses the random tmp dir path leaking into compiled C-extensions.

First, adds a `build-inplace` PEP 517 config setting and a `PROPCACHE_BUILD_INPLACE` environment variable so downstream packagers can opt the wheel build into the source tree, skipping the tmp dir entirely. Editable installs still build in-tree as before.

Second, when the default tmp-dir build is used, the backend now injects `-ffile-prefix-map=$tmpdir=$srcdir` into CFLAGS, so debug paths in the resulting C-extensions are normalized to the original source path. This makes the default wheel build reproducible without any opt-in.

## Are there changes in behavior for the user?

End users see no behavior change; default build paths now produce deterministic compiled artifacts. Downstream packagers get a new opt-in (`--config-setting=build-inplace=true`) for in-tree builds.

## Related issue number

Closes #68

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes