### PR TITLE
Skip cibuildwheel test on free threaded armv7l musllinux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,10 @@ before-test = [
 ]
 test-requires = "-r requirements/test.txt"
 test-command = "pytest -v --no-cov {project}/tests"
+# Free-threaded CPython under armv7l QEMU emulation crashes with SIGBUS when
+# importing the C extension; the wheel runs fine on real armv7l hardware, so
+# build and ship it but skip the emulated post-build test.
+test-skip = "*t-musllinux_armv7l"
 # don't build PyPy wheels, install from source instead
 skip = "pp*"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The cp314t musllinux armv7l job in v0.5.0 CI aborted with SIGBUS during cibuildwheel's post build pytest run while importing the C extension under QEMU; this adds `test-skip = "*t-musllinux_armv7l"` so the wheel still builds and ships while the emulated test is skipped.

The wheel itself runs fine on real armv7l hardware, and the other cp314t test jobs (ubuntu, macos, windows, windows 11 arm) all passed in the same run, so freethreaded test coverage is still in place; this looks like a QEMU armv7l emulation issue, not a real platform bug.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No; wheels still build and publish for cp314t musllinux armv7l, only the emulated post build test is skipped.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

None filed; needed for v0.5.1 since v0.5.0 never published due to this failure.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes