### PR TITLE
Migrate code formatting from black + isort to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,15 +16,23 @@ repos:
   - id: yesqa
     additional_dependencies:
     - wemake-python-styleguide
-- repo: https://github.com/PyCQA/isort
-  rev: '8.0.1'
+- repo: https://github.com/astral-sh/ruff-pre-commit.git
+  rev: v0.15.13
   hooks:
-  - id: isort
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: '26.3.1'
-  hooks:
-  - id: black
-    language_version: python3  # Should be a command that runs python
+  - id: ruff-check
+    name: ruff check | propcache & tests
+    # Uses the [tool.ruff] config in pyproject.toml. Enforces `I`
+    # (import sorting, replacing isort). Runs before ruff-format
+    # because --fix is used.
+    args:
+    # Ref: https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    - --exit-non-zero-on-fix
+    - --fix
+    - --show-fixes
+  - id: ruff-format
+    name: ruff format | propcache & tests
+    # Replaces the standalone black hook. Defaults to a black-compatible
+    # 88-column style; no [tool.ruff.format] overrides in pyproject.toml.
 
 - repo: https://github.com/python-jsonschema/check-jsonschema.git
   rev: 0.37.1

--- a/CHANGES/232.contrib.rst
+++ b/CHANGES/232.contrib.rst
@@ -1,0 +1,6 @@
+Migrated from standalone ``black`` and ``isort`` pre-commit hooks
+to ``ruff format`` and the ruff ``I`` lint rule, sharing a new
+``[tool.ruff]`` config in ``pyproject.toml``. ``ruff-check`` runs
+with ``--fix`` so import-order fixes apply on commit, and the
+orphan ``[isort]`` block in ``setup.cfg`` was removed
+-- by :user:`bdraco`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,17 @@ before-test = []  # Windows cmd has different syntax and pip chooses wheels
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y libffi-devel || apk add --upgrade libffi-dev || apt-get install libffi-dev"
+
+[tool.ruff.lint]
+# Keep this list small and intentional; the rest of the project still
+# relies on flake8 for general style. The rules below are ones we want
+# to enforce repo-wide as a baseline.
+select = [
+  # Import sorting. Replaces the dedicated isort pre-commit hook so the
+  # formatter (ruff format) and the import sorter (ruff check --select I)
+  # come from the same tool and rev.
+  "I",
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["propcache"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,6 +92,3 @@ per-file-ignores =
 
   # F401   imported but unused
   packaging/pep517_backend/hooks.py: F401
-
-[isort]
-profile=black

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -76,7 +76,6 @@ def test_cached_property_cache_miss(benchmark: "BenchmarkFixture") -> None:
     """Benchmark for cached_property cache miss."""
 
     class Test:
-
         @cached_property
         def prop(self) -> int:
             """Return the value of the property."""

--- a/tests/test_cached_property.py
+++ b/tests/test_cached_property.py
@@ -39,7 +39,6 @@ def test_cached_property(propcache_module: APIProtocol) -> None:
 
 def test_cached_property_without_cache(propcache_module: APIProtocol) -> None:
     class A:
-
         __slots__ = ()
 
         def __init__(self) -> None:
@@ -57,7 +56,6 @@ def test_cached_property_without_cache(propcache_module: APIProtocol) -> None:
 
 def test_cached_property_check_without_cache(propcache_module: APIProtocol) -> None:
     class A:
-
         __slots__ = ()
 
         def __init__(self) -> None:
@@ -106,7 +104,6 @@ def test_set_name(propcache_module: APIProtocol) -> None:
     """Test that the __set_name__ method is called and checked."""
 
     class A:
-
         @propcache_module.cached_property
         def prop(self) -> None:
             """Docstring."""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Drop the standalone ``black`` and ``isort`` pre-commit hooks and use ruff for both formatting and import sorting. Adds a ``[tool.ruff.lint]`` block in ``pyproject.toml`` selecting the ``I`` rule (with ``known-first-party = ["propcache"]`` so the existing ``pytest`` / ``propcache`` two-section import layout is preserved) and replaces the two old hooks with ``ruff-check`` (run with ``--fix --exit-non-zero-on-fix --show-fixes`` so import-sorting fixes apply on commit) and ``ruff-format``. The orphan ``[isort]`` block in ``setup.cfg`` is removed.

``ruff format`` applied four small reformats across ``tests/test_benchmarks.py`` and ``tests/test_cached_property.py``: stray blank lines after class headers were removed. ``ruff check --select I`` produced no diffs against the existing import order, so the isort half of the swap is a no-op on imports.

## Are there changes in behavior for the user?

No, contributor tooling only.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (tooling-only change; ran ``pre-commit run --all-files`` and ``ruff check`` / ``ruff format --check`` against the reformatted tree)
- [x] Documentation reflects the changes: N/A (no user-visible API change)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``: N/A (no such file in this repo)
- [x] Add a new news fragment into the ``CHANGES/`` folder (``CHANGES/232.contrib.rst``)

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Verified:

```
$ ruff check src/ tests/ docs/ packaging/
All checks passed!
$ ruff format --check src/ tests/ docs/ packaging/
19 files already formatted
$ pre-commit run --all-files
all hooks Passed (actionlint-docker skipped: Docker daemon not running locally)
$ make doc-spelling
2 pre-existing misspellings only ("subdirectory" in CHANGES/207.contrib.rst, "postfix" in CHANGES.rst); the new CHANGES/232.contrib.rst fragment is clean.
```

</details>