### PR TITLE
Cache the cibuildwheel C extension build with ccache on Linux and macOS

### DIFF
--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -100,21 +100,19 @@ jobs:
         max-size: 200M
 
     - name: Wire ccache into the cibuildwheel Linux container
-      # The manylinux/musllinux container ships without ccache and can't see
-      # the host's cache dir by default. `before-all` (in pyproject.toml)
-      # installs ccache inside the container; here we bind-mount the host
-      # cache dir and prepend the in-container ccache compiler symlinks to
-      # PATH so build_ext picks them up transparently.
+      # `cibuildwheel` already mounts the host filesystem at `/host` inside
+      # the manylinux/musllinux build container, so the cache dir set up by
+      # `hendrikmuhs/ccache-action` on the runner is reachable at
+      # `/host${cache_dir}`. The in-container ccache (installed via
+      # `before-all` in `pyproject.toml`) reads and writes through that
+      # mount. The cache dir is read straight from `ccache --get-config`
+      # because the action does not export `CCACHE_DIR` to `GITHUB_ENV`.
       if: runner.os == 'Linux' && !inputs.qemu
       run: |
-        mount="/host_ccache"
-        engine="docker; create_args: --volume=${CCACHE_DIR}:${mount}"
+        host_cache="$(ccache --get-config cache_dir)"
         cc_dirs="/usr/lib64/ccache:/usr/lib/ccache/bin:/usr/lib/ccache"
-        cibw_env="PATH=${cc_dirs}:\$PATH CCACHE_DIR=${mount}"
-        {
-          echo "CIBW_CONTAINER_ENGINE=${engine}"
-          echo "CIBW_ENVIRONMENT_LINUX=${cibw_env}"
-        } >> "${GITHUB_ENV}"
+        cibw_env="PATH=${cc_dirs}:\$PATH CCACHE_DIR=/host${host_cache}"
+        echo "CIBW_ENVIRONMENT_LINUX=${cibw_env}" >> "${GITHUB_ENV}"
       shell: bash
 
     - name: Build wheels

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -82,6 +82,41 @@ jobs:
         echo "CIBW_SKIP=${{ inputs.wheel-tags-to-skip }}" >> "${GITHUB_ENV}"
       shell: bash
 
+    # Compiler cache for the C extension: each wheel-build job compiles the
+    # same `_helpers_c.c` once per Python ABI. With ccache, a warm cache turns
+    # ~25-40 s of per-ABI recompilation into a sub-second hit when neither the
+    # generated `.c`, the `Python.h` for that ABI, nor the toolchain has
+    # changed. Skipped under QEMU because the host cache holds foreign-arch
+    # objects. Windows is not wired up: setuptools' MSVCCompiler invokes
+    # cl.exe directly and ignores CC/CXX, so a sccache integration there
+    # requires a cl.exe shim and is left as a separate piece of work.
+    - name: Set up ccache
+      if: runner.os != 'Windows' && !inputs.qemu
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: >-
+          ccache-${{ inputs.os }}-${{ inputs.tag
+          }}-${{ inputs.cython-tracing }}
+        max-size: 200M
+
+    - name: Wire ccache into the cibuildwheel Linux container
+      # The manylinux/musllinux container ships without ccache and can't see
+      # the host's cache dir by default. `before-all` (in pyproject.toml)
+      # installs ccache inside the container; here we bind-mount the host
+      # cache dir and prepend the in-container ccache compiler symlinks to
+      # PATH so build_ext picks them up transparently.
+      if: runner.os == 'Linux' && !inputs.qemu
+      run: |
+        mount="/host_ccache"
+        engine="docker; create_args: --volume=${CCACHE_DIR}:${mount}"
+        cc_dirs="/usr/lib64/ccache:/usr/lib/ccache/bin:/usr/lib/ccache"
+        cibw_env="PATH=${cc_dirs}:\$PATH CCACHE_DIR=${mount}"
+        {
+          echo "CIBW_CONTAINER_ENGINE=${engine}"
+          echo "CIBW_ENVIRONMENT_LINUX=${cibw_env}"
+        } >> "${GITHUB_ENV}"
+      shell: bash
+
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.4.1
       env:

--- a/CHANGES/233.contrib.rst
+++ b/CHANGES/233.contrib.rst
@@ -1,0 +1,6 @@
+Wrapped the Linux and macOS C compiler with ``ccache`` in the
+``cibuildwheel`` matrix. The ``_helpers_c.c`` build for each
+Python version is now read from cache on warm runs instead of
+being recompiled from scratch, dropping the slowest wheel jobs by
+roughly half on cache hits
+-- by :user:`bdraco`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,10 @@ pure-python = "false"
 before-test = []  # Windows cmd has different syntax and pip chooses wheels
 
 [tool.cibuildwheel.linux]
-before-all = "yum install -y libffi-devel || apk add --upgrade libffi-dev || apt-get install libffi-dev"
+# ccache is installed alongside libffi-devel so the compiler-cache wrapping
+# configured by the CI workflow (PATH=/usr/lib64/ccache:... + bind-mounted
+# CCACHE_DIR) actually finds a ccache binary inside the build container.
+before-all = "(yum install -y libffi-devel ccache) || (apk add --upgrade libffi-dev ccache) || (apt-get install -y libffi-dev ccache)"
 
 [tool.ruff.lint]
 # Keep this list small and intentional; the rest of the project still


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Wrap the C compiler inside the ``cibuildwheel`` matrix with
``ccache`` so that ``_helpers_c.c`` is not rebuilt from scratch
for every Python version on every CI run.
``hendrikmuhs/ccache-action`` provisions the cache on the runner.

On Linux, ``cibuildwheel`` already bind-mounts the runner
filesystem at ``/host`` inside the manylinux/musllinux container,
so no custom container-engine override is needed; the
in-container ``ccache`` (installed alongside ``libffi-devel`` in
the existing ``before-all``) is wired up by prepending the
ccache compiler symlink dirs to ``PATH`` and pointing
``CCACHE_DIR`` at ``/host\${cache_dir}`` via
``CIBW_ENVIRONMENT_LINUX``. The cache dir itself is read from
``ccache --get-config cache_dir`` because the action does not
export it to ``GITHUB_ENV``.

macOS picks up the action's compiler symlinks directly through
``PATH``. QEMU jobs are skipped (host cache holds foreign-arch
objects).

Windows is intentionally left out for now: setuptools'
``MSVCCompiler`` invokes ``cl.exe`` directly and ignores
``CC``/``CXX``, so an ``sccache`` integration there needs a
``cl.exe`` shim earlier in ``PATH`` and is deferred to a separate
piece of work.

Expected effect on warm cache: the per-Python-version compile of
``_helpers_c.c`` drops from roughly 25 to 40 seconds to a
sub-second hit, bringing the slowest Linux and macOS wheel jobs
down by roughly half.

## Are there changes in behavior for the user?

No, contributor tooling only.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (CI-only change; ``ruff``/``ruff format``/``yamllint`` run via pre-commit, and ``make doc-spelling`` is clean against the new fragment)
- [x] Documentation reflects the changes: N/A (no user-visible API change)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``: N/A (no such file in this repo)
- [x] Add a new news fragment into the ``CHANGES/`` folder (``CHANGES/233.contrib.rst``)

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

First push (commit ``2ad0e88``) crashed all four wheel jobs on
Linux with ``docker: invalid spec: :/host_ccache: empty section
between colons``. Root cause: ``hendrikmuhs/ccache-action`` does
not export ``CCACHE_DIR`` to ``GITHUB_ENV`` (it configures ccache
via ``ccache --set-config cache_dir=...``), so the custom
``CIBW_CONTAINER_ENGINE`` mount expanded to an empty source.
Windows and macOS were cancelled by fail-fast.

Follow-up commit (``efe94c3``) drops the custom container-engine
override, relies on ``cibuildwheel``'s default ``/:/host`` mount,
and reads the cache dir from ``ccache --get-config cache_dir``,
referencing it at ``/host\${cache_dir}`` inside the container.
The "Wire ccache" step shrank by roughly half.

Local validation:

\`\`\`
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/reusable-build-wheel.yml'))"
$ python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"
$ make doc-spelling
2 pre-existing misspellings only ("subdirectory" in CHANGES/207.contrib.rst, "postfix" in CHANGES.rst); CHANGES/233.contrib.rst is clean.
$ SKIP=actionlint-docker pre-commit run --all-files
all hooks pass (actionlint-docker skipped: Docker daemon not running locally; runs in CI).
\`\`\`

Container behavior cannot be exercised locally; the live CI run
on this branch is the verification.
</details>