### PR TITLE
Switch cibuildwheel to the uv build frontend

### DIFF
--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -84,6 +84,12 @@ jobs:
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.4.1
+      with:
+        # `build-frontend = "build[uv]"` (pyproject.toml) requires uv to be
+        # available on the runner for Windows and macOS. Installing
+        # cibuildwheel with the `uv` extra bundles uv with it; Linux
+        # already has uv inside the manylinux/musllinux container.
+        extras: uv
       env:
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
         CIBW_CONFIG_SETTINGS: >-  # Cython line tracing for coverage collection

--- a/CHANGES/234.contrib.rst
+++ b/CHANGES/234.contrib.rst
@@ -1,0 +1,6 @@
+Switched the ``cibuildwheel`` build frontend to ``build[uv]`` so
+that ``uv`` provisions every build and test virtual environment
+in the wheel matrix. Test-dependency installation in particular
+drops from a multi-second ``pip install`` per ABI to a roughly
+sub-second ``uv`` resolve
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -26,6 +26,7 @@ dev
 dists
 downstreams
 facto
+frontend
 glibc
 google
 hardcoded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,15 +69,6 @@ emit_code_comments = "True"
 # pip-based path took noticeably longer per ABI and ran once per matrix
 # cell.
 build-frontend = "build[uv]"
-before-test = [
-  # NOTE: Attempt to have pip pre-compile PyYAML wheel with our build
-  # NOTE: constraints unset. The hope is that pip will cache that wheel
-  # NOTE: and the test env provisioning stage will pick up PyYAML from
-  # NOTE: said cache rather than attempting to build it with a conflicting.
-  # NOTE: Version of Cython.
-  # Ref: https://github.com/pypa/cibuildwheel/issues/1666
-  "PIP_CONSTRAINT= pip install PyYAML",
-]
 test-requires = "-r requirements/test.txt"
 test-command = "pytest -v --no-cov {project}/tests"
 # Free-threaded CPython under armv7l QEMU emulation crashes with SIGBUS when
@@ -97,9 +88,6 @@ PY_COLORS = "1"
 
 [tool.cibuildwheel.config-settings]
 pure-python = "false"
-
-[tool.cibuildwheel.windows]
-before-test = []  # Windows cmd has different syntax and pip chooses wheels
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y libffi-devel || apk add --upgrade libffi-dev || apt-get install libffi-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,13 @@ emit_code_comments = "True"
 #error_on_uninitialized = "True"
 
 [tool.cibuildwheel]
-build-frontend = "build"
+# `build[uv]` makes cibuildwheel use `uv` for every venv it provisions,
+# both on the build side (passed to `python -m build` as `--installer=uv`)
+# and when materializing the test environment. uv resolves and installs
+# the wheel plus `requirements/test.txt` in roughly a second; the previous
+# pip-based path took noticeably longer per ABI and ran once per matrix
+# cell.
+build-frontend = "build[uv]"
 before-test = [
   # NOTE: Attempt to have pip pre-compile PyYAML wheel with our build
   # NOTE: constraints unset. The hope is that pip will cache that wheel


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Set ``build-frontend = "build[uv]"`` in
``[tool.cibuildwheel]`` so that ``uv`` provisions every virtual
environment cibuildwheel creates, both on the build side (passed
to ``python -m build`` as ``--installer=uv``) and when
materializing the per-ABI test environment. The previous
``build-frontend = "build"`` left every test env doing a
multi-second pip resolve of ``requirements/test.txt`` per ABI;
``uv`` resolves and installs the same set in roughly a second,
which compounds across the seven ABIs and four host platforms in
the wheel matrix.

Also adds ``frontend`` to ``docs/spelling_wordlist.txt`` so the
news fragment passes the docs spell check.

## Are there changes in behavior for the user?

No, contributor tooling only.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (CI-only change; the wheel-matrix run on this PR is the verification path)
- [x] Documentation reflects the changes: N/A (no user-visible API change)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``: N/A (no such file in this repo)
- [x] Add a new news fragment into the ``CHANGES/`` folder (``CHANGES/234.contrib.rst``)

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Local validation:

\`\`\`
$ python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"
$ make doc-spelling
2 pre-existing misspellings only ("subdirectory" in CHANGES/207.contrib.rst, "postfix" in CHANGES.rst); CHANGES/234.contrib.rst is clean after adding "frontend" to the wordlist.
$ SKIP=actionlint-docker pre-commit run --all-files
all hooks pass (actionlint-docker skipped: Docker daemon not running locally; runs in CI).
\`\`\`

Not verified locally: the actual cibuildwheel + uv interaction
inside the build container; that requires running cibuildwheel
which is impractical without pushing. The live CI run on this
branch is the verification. Existing ``PIP_CONSTRAINT`` in
``[tool.cibuildwheel.environment]`` is left in place; uv ignores
it (uv reads ``UV_CONSTRAINT`` / ``UV_BUILD_CONSTRAINT``), and if
the wheel build ends up needing the Cython pin to apply during
uv-driven build dependency resolution, a follow-up can add a
parallel ``UV_BUILD_CONSTRAINT`` entry. The ``before-test``
PyYAML pre-cache (``"PIP_CONSTRAINT= pip install PyYAML"``) was
also left untouched; it becomes a no-op under uv but is harmless
and removing it is out of scope for this PR.

Independent of and stacks naturally with #233 (ccache wrapping
for the C compile); the two PRs touch different cibuildwheel
config sections and different workflow steps.
</details>