### PR TITLE
Wire ccache into the cibuildwheel macOS build

### DIFF
--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -115,6 +115,20 @@ jobs:
         echo "CIBW_ENVIRONMENT_LINUX=${cibw_env}" >> "${GITHUB_ENV}"
       shell: bash
 
+    - name: Wire ccache into the cibuildwheel macOS build
+      # Brew ships compiler-named shims under
+      # `$(brew --prefix ccache)/libexec`; prepending that to `PATH`
+      # via `CIBW_ENVIRONMENT_MACOS` routes setuptools' bare `clang`
+      # / `cc` lookups through ccache. `brew --prefix` keeps this
+      # working on both `/opt/homebrew` and `/usr/local` runners.
+      if: runner.os == 'macOS' && !inputs.qemu
+      run: |
+        libexec="$(brew --prefix ccache)/libexec"
+        host_cache="$(ccache --get-config cache_dir)"
+        cibw_env="PATH=${libexec}:\$PATH CCACHE_DIR=${host_cache}"
+        echo "CIBW_ENVIRONMENT_MACOS=${cibw_env}" >> "${GITHUB_ENV}"
+      shell: bash
+
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.4.1
       with:

--- a/CHANGES/235.contrib.rst
+++ b/CHANGES/235.contrib.rst
@@ -1,0 +1,1 @@
+233.contrib.rst


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds a `Wire ccache into the cibuildwheel macOS build` step in
`.github/workflows/reusable-build-wheel.yml` that sets
`CIBW_ENVIRONMENT_MACOS` to prepend `$(brew --prefix ccache)/libexec`
to `PATH` and propagate `CCACHE_DIR`, so setuptools' bare `clang` /
`cc` lookups hit Brew's ccache shims. Mirrors the existing Linux step.

The macOS half of #233 was a no-op: the ccache action installed and
configured ccache, but cibuildwheel ran plain `clang` from Xcode, so
the job logged `Cache size (GB): 0.0 / 0.2 ( 0.00%)` followed by
`Not saving cache because no objects are cached.` Linux already works
because `CIBW_ENVIRONMENT_LINUX` puts `/usr/lib*/ccache` on `PATH`
inside the manylinux container; macOS had no equivalent.

`brew --prefix ccache` resolves correctly on both Apple-silicon
(`/opt/homebrew`) and Intel (`/usr/local`) runners.

## Are there changes in behavior for the user?

No. CI-only change. The published wheels are byte-identical; only the
macOS wheel-build job is affected (it should populate the ccache cache
on the first run and serve cache hits on subsequent runs).

## Related issue number

Follow-up to #233.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist -- N/A (CI workflow change; the
  effect is observable only by re-running the wheel-build matrix)
- [ ] Documentation reflects the changes -- N/A (no user-visible API)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Diagnosis from the #233 merge run
([job 76422386592](https://github.com/aio-libs/propcache/actions/runs/26000293687/job/76422386592)):

```
ccache stats
  Cache size (GB): 0.0 / 0.2 ( 0.00%)
ccache version 4.13.5
...
Not saving cache because no objects are cached.
```

Linux on the same run did save a 274 KB `cache.tzst` with 7 cacheable
misses, so this is a macOS-only gap.

Local checks:

- `actionlint .github/workflows/reusable-build-wheel.yml`: clean.
- `make doc-spelling`: passes for this change. `CHANGES/235.contrib.rst`
  is a symlink to `CHANGES/233.contrib.rst` (per AGENTS.md), so no new
  fragment text or wordlist entries are introduced. Two pre-existing
  failures remain on master that are unrelated to this change
  (`subdirectory` in `CHANGES/207.contrib.rst:1` and `postfix` in
  `CHANGES.rst:168`).
- Pre-commit hooks (actionlint-docker, yamllint, codespell, etc.) pass.

The runtime effect cannot be exercised locally; verification is the
next macOS wheel-build job on this branch.

Drafted with Claude Code (Claude Opus 4.7); reviewed by @bdraco.
</details>

