### PR TITLE
Drop libffi-devel from the cibuildwheel Linux before-all step

### DIFF
--- a/CHANGES/236.contrib.rst
+++ b/CHANGES/236.contrib.rst
@@ -1,0 +1,6 @@
+Dropped the ``libffi-devel`` install from the ``cibuildwheel``
+Linux ``before-all`` step. It was added in :pr:`75` so
+``cffi`` could build from source during wheel testing; the
+current wheel-test chain no longer pulls in ``cffi``, so the
+header package is dead weight
+-- by :user:`bdraco`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,10 +90,10 @@ PY_COLORS = "1"
 pure-python = "false"
 
 [tool.cibuildwheel.linux]
-# ccache is installed alongside libffi-devel so the compiler-cache wrapping
+# Install ccache in the build container so the compiler-cache wrapping
 # configured by the CI workflow (PATH=/usr/lib64/ccache:... + bind-mounted
-# CCACHE_DIR) actually finds a ccache binary inside the build container.
-before-all = "(yum install -y libffi-devel ccache) || (apk add --upgrade libffi-dev ccache) || (apt-get install -y libffi-dev ccache)"
+# CCACHE_DIR) actually finds a ccache binary.
+before-all = "(yum install -y ccache) || (apk add --upgrade ccache) || (apt-get install -y ccache)"
 
 [tool.ruff.lint]
 # Keep this list small and intentional; the rest of the project still


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Removes the ``libffi-devel`` install from
``[tool.cibuildwheel.linux] before-all`` in ``pyproject.toml``,
leaving the step responsible only for installing ``ccache``.

History: ``libffi-devel`` was added in #75 (Dec 2024, "Fix wheel builds
when cffi needs to be built from source") because ``cffi`` was being
built from source during the wheel test environment install, and
``cffi``'s build requires libffi headers. Today the wheel test chain
(``requirements/test.txt``: cython, covdefaults, pytest, pytest-cov,
pytest-xdist) and the build-system requires (expandvars, setuptools,
tomli) do not pull ``cffi``. The only remaining ``cffi`` reference is
``requirements/codspeed.txt``, which is installed by the CodSpeed
benchmark job on a regular ubuntu-latest runner where libffi-dev is
already present and which does not use cibuildwheel.

## Are there changes in behavior for the user?

No. CI-only change. The published wheels and the test command run by
cibuildwheel are unchanged; the only effect is a slightly faster
``before-all`` (one fewer package installed, fewer yum/apt/apk fetches).

## Related issue number

Follow-up cleanup spotted while reviewing #233 / #235.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist -- N/A (CI workflow change; the
  effect is observable only by re-running the wheel-build matrix)
- [ ] Documentation reflects the changes -- N/A (no user-visible API)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

History trace:

- Introduced: `git show 08091df` (PR #75, "Fix wheel builds when cffi
  needs to be built from source"; references the same fix in
  aio-libs/multidict#1015).
- Reinforced: `git show 36ec052` ("Revert building armv7l manylinux
  wheels / libcffi-dev is not available in the manylinux armv7
  images") -- confirming that the only consumer of ``libffi-devel``
  was ``cffi``.

Dep audit (current `master`):

- `grep -l cffi requirements/*.txt` -> only `requirements/codspeed.txt`.
- `requirements/test.txt` -> `cython.txt` + covdefaults + pytest +
  pytest-cov + pytest-xdist. None of these pull `cffi` transitively.
- `pyproject.toml` build-system requires -> expandvars, setuptools,
  tomli. None pull `cffi`.

Local checks:

- `make doc-spelling`: passes for the new fragment. Two pre-existing
  failures remain on master that are unrelated to this change
  (`subdirectory` in `CHANGES/207.contrib.rst:1` and `postfix` in
  `CHANGES.rst:168`).
- Pre-commit hooks (toml check, codespell, etc.) pass.

The runtime effect cannot be exercised locally; verification is the
next Linux wheel-build job on this branch.

Drafted with Claude Code (Claude Opus 4.7); reviewed by @bdraco.
</details>