### PR TITLE
DNM: capture ccache debug logs from cibuildwheel wheel jobs

### DIFF
--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -107,11 +107,17 @@ jobs:
       # `before-all` in `pyproject.toml`) reads and writes through that
       # mount. The cache dir is read straight from `ccache --get-config`
       # because the action does not export `CCACHE_DIR` to `GITHUB_ENV`.
+      # DNM-DEBUG: CCACHE_DEBUG + CCACHE_LOGFILE capture per-compilation
+      # hash inputs so we can diff two runs and see why every compile
+      # misses. Remove before merging.
       if: runner.os == 'Linux' && !inputs.qemu
       run: |
         host_cache="$(ccache --get-config cache_dir)"
         cc_dirs="/usr/lib64/ccache:/usr/lib/ccache/bin:/usr/lib/ccache"
-        cibw_env="PATH=${cc_dirs}:\$PATH CCACHE_DIR=/host${host_cache}"
+        log="${GITHUB_WORKSPACE}/ccache-debug.log"
+        cibw_env="PATH=${cc_dirs}:\$PATH"
+        cibw_env+=" CCACHE_DIR=/host${host_cache}"
+        cibw_env+=" CCACHE_DEBUG=1 CCACHE_LOGFILE=/host${log}"
         echo "CIBW_ENVIRONMENT_LINUX=${cibw_env}" >> "${GITHUB_ENV}"
       shell: bash
 
@@ -121,11 +127,15 @@ jobs:
       # via `CIBW_ENVIRONMENT_MACOS` routes setuptools' bare `clang`
       # / `cc` lookups through ccache. `brew --prefix` keeps this
       # working on both `/opt/homebrew` and `/usr/local` runners.
+      # DNM-DEBUG: see Linux step above.
       if: runner.os == 'macOS' && !inputs.qemu
       run: |
         libexec="$(brew --prefix ccache)/libexec"
         host_cache="$(ccache --get-config cache_dir)"
-        cibw_env="PATH=${libexec}:\$PATH CCACHE_DIR=${host_cache}"
+        log="${GITHUB_WORKSPACE}/ccache-debug.log"
+        cibw_env="PATH=${libexec}:\$PATH"
+        cibw_env+=" CCACHE_DIR=${host_cache}"
+        cibw_env+=" CCACHE_DEBUG=1 CCACHE_LOGFILE=${log}"
         echo "CIBW_ENVIRONMENT_MACOS=${cibw_env}" >> "${GITHUB_ENV}"
       shell: bash
 
@@ -151,5 +161,17 @@ jobs:
           ${{ inputs.qemu }}-
           ${{ inputs.tag }}
         path: ./wheelhouse/*.whl
+
+    # DNM-DEBUG: collect ccache log + per-compilation debug dumps so the
+    # cache-miss investigation can compare two runs. Remove before merging.
+    - name: Upload ccache debug artifact (DNM)
+      if: always() && runner.os != 'Windows' && !inputs.qemu
+      uses: actions/upload-artifact@v7
+      with:
+        name: ccache-debug-${{ inputs.os }}-${{ inputs.qemu }}-${{ inputs.tag }}
+        path: |
+          ccache-debug.log
+          .ccache/debug
+        if-no-files-found: warn
 
 ...


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Diagnostic-only. Adds two things to ``.github/workflows/reusable-build-wheel.yml``:

1. ``CCACHE_DEBUG=1`` and
   ``CCACHE_LOGFILE=$GITHUB_WORKSPACE/ccache-debug.log`` in the
   existing ``CIBW_ENVIRONMENT_LINUX`` and ``CIBW_ENVIRONMENT_MACOS``
   wiring, so every ccache invocation during the wheel build records
   its hash inputs.
2. An ``actions/upload-artifact`` step that publishes the resulting
   ``ccache-debug.log`` and the ``$CCACHE_DIR/debug/`` per-compilation
   hash-input dumps.

After #235 landed, the cache restores cleanly on both Linux and macOS,
but every compile still records as a cache miss (0/12 hits on macOS,
0/6 on Linux) and the cache size strictly grows across runs. Something
ccache hashes is varying between runs of the same source. Strongest
hypothesis is pip build-isolation's randomly-named tmp dir
(``/tmp/.tmp-propcache-pep517-XXXX``) leaking into the compiler argv,
but the debug dumps will show for sure. Diff the manifests from two
consecutive runs and the variable input is identified.

**Do not merge.** This PR is purely to collect artifacts; once the
cause is known, the fix lands in a separate PR and this branch is
abandoned.

## Are there changes in behavior for the user?

No. CI-only diagnostic, marked DNM in the title and commit.

## Related issue number

Diagnoses the cache-miss behavior observed after #233 / #235.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist -- N/A (CI diagnostic)
- [ ] Documentation reflects the changes -- N/A (no user-visible API)
- [ ] Add a new news fragment into the `CHANGES/` folder -- N/A
  (DNM; will not ship, no changelog entry needed)

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Method:

1. Run this PR's wheel jobs once.
2. Wait, then re-run the workflow (or push a no-op) so a second run
   restores the cache the first run saved.
3. Download the ``ccache-debug-*`` artifacts from both runs.
4. Diff a corresponding pair of per-compilation manifests under
   ``.ccache/debug/``. The first differing field is the offending hash
   input -- compiler binary, compiler args (likely contains the build
   tmp dir path), preprocessed source, or working dir.

Local checks:

- ``actionlint .github/workflows/reusable-build-wheel.yml``: clean.
- ``yamllint`` via pre-commit: clean (long ``cibw_env`` assignment
  split with ``+=`` to stay under 80 columns).
- ``make doc-spelling`` not run -- no ``.rst`` change.

Drafted with Claude Code (Claude Opus 4.7); reviewed by @bdraco.
</details>