### PR TITLE
Remove ccache from the cibuildwheel matrix

### DIFF
--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -82,53 +82,6 @@ jobs:
         echo "CIBW_SKIP=${{ inputs.wheel-tags-to-skip }}" >> "${GITHUB_ENV}"
       shell: bash
 
-    # Compiler cache for the C extension: each wheel-build job compiles the
-    # same `_helpers_c.c` once per Python ABI. With ccache, a warm cache turns
-    # ~25-40 s of per-ABI recompilation into a sub-second hit when neither the
-    # generated `.c`, the `Python.h` for that ABI, nor the toolchain has
-    # changed. Skipped under QEMU because the host cache holds foreign-arch
-    # objects. Windows is not wired up: setuptools' MSVCCompiler invokes
-    # cl.exe directly and ignores CC/CXX, so a sccache integration there
-    # requires a cl.exe shim and is left as a separate piece of work.
-    - name: Set up ccache
-      if: runner.os != 'Windows' && !inputs.qemu
-      uses: hendrikmuhs/ccache-action@v1
-      with:
-        key: >-
-          ccache-${{ inputs.os }}-${{ inputs.tag
-          }}-${{ inputs.cython-tracing }}
-        max-size: 200M
-
-    - name: Wire ccache into the cibuildwheel Linux container
-      # `cibuildwheel` already mounts the host filesystem at `/host` inside
-      # the manylinux/musllinux build container, so the cache dir set up by
-      # `hendrikmuhs/ccache-action` on the runner is reachable at
-      # `/host${cache_dir}`. The in-container ccache (installed via
-      # `before-all` in `pyproject.toml`) reads and writes through that
-      # mount. The cache dir is read straight from `ccache --get-config`
-      # because the action does not export `CCACHE_DIR` to `GITHUB_ENV`.
-      if: runner.os == 'Linux' && !inputs.qemu
-      run: |
-        host_cache="$(ccache --get-config cache_dir)"
-        cc_dirs="/usr/lib64/ccache:/usr/lib/ccache/bin:/usr/lib/ccache"
-        cibw_env="PATH=${cc_dirs}:\$PATH CCACHE_DIR=/host${host_cache}"
-        echo "CIBW_ENVIRONMENT_LINUX=${cibw_env}" >> "${GITHUB_ENV}"
-      shell: bash
-
-    - name: Wire ccache into the cibuildwheel macOS build
-      # Brew ships compiler-named shims under
-      # `$(brew --prefix ccache)/libexec`; prepending that to `PATH`
-      # via `CIBW_ENVIRONMENT_MACOS` routes setuptools' bare `clang`
-      # / `cc` lookups through ccache. `brew --prefix` keeps this
-      # working on both `/opt/homebrew` and `/usr/local` runners.
-      if: runner.os == 'macOS' && !inputs.qemu
-      run: |
-        libexec="$(brew --prefix ccache)/libexec"
-        host_cache="$(ccache --get-config cache_dir)"
-        cibw_env="PATH=${libexec}:\$PATH CCACHE_DIR=${host_cache}"
-        echo "CIBW_ENVIRONMENT_MACOS=${cibw_env}" >> "${GITHUB_ENV}"
-      shell: bash
-
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.4.1
       with:

--- a/CHANGES/233.contrib.rst
+++ b/CHANGES/233.contrib.rst
@@ -1,6 +1,0 @@
-Wrapped the Linux and macOS C compiler with ``ccache`` in the
-``cibuildwheel`` matrix. The ``_helpers_c.c`` build for each
-Python version is now read from cache on warm runs instead of
-being recompiled from scratch, dropping the slowest wheel jobs by
-roughly half on cache hits
--- by :user:`bdraco`.

--- a/CHANGES/235.contrib.rst
+++ b/CHANGES/235.contrib.rst
@@ -1,1 +1,0 @@
-233.contrib.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,12 +89,6 @@ PY_COLORS = "1"
 [tool.cibuildwheel.config-settings]
 pure-python = "false"
 
-[tool.cibuildwheel.linux]
-# Install ccache in the build container so the compiler-cache wrapping
-# configured by the CI workflow (PATH=/usr/lib64/ccache:... + bind-mounted
-# CCACHE_DIR) actually finds a ccache binary.
-before-all = "(yum install -y ccache) || (apk add --upgrade ccache) || (apt-get install -y ccache)"
-
 [tool.ruff.lint]
 # Keep this list small and intentional; the rest of the project still
 # relies on flake8 for general style. The rules below are ones we want


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Reverts the ccache wiring from #233 and #235. It was a good idea but
didn't pan out: ``Cython`` embeds the absolute ``.pyx`` source path
in a metadata block at the top of every generated ``.c``, which
breaks ccache's direct-mode hash, and the macOS Python 3.13+
compiler output is non-deterministic at the linker level on top of
that. Best case observed was 50% preprocessor-mode hits, 0% direct.

## Are there changes in behavior for the user?

No. CI-only revert. Wheels are unchanged.

## Related issue number

Reverts the ccache pieces of #233 and #235.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist -- N/A
- [ ] Documentation reflects the changes -- N/A
- [ ] Add a new news fragment into the `CHANGES/` folder -- N/A
  (the original #233 / #235 fragments are also removed; nothing
  about ccache ever ships)

Drafted with Claude Code (Claude Opus 4.7); reviewed by @bdraco.