### PR TITLE
ci: install Python via astral-sh/setup-uv to skip 40-58s downloads

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -76,21 +76,13 @@ jobs:
     - name: Checkout project
       uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ env.PYTHON_LATEST }}
-    - name: >-
-        Calculate dependency files' combined hash value
-        for use in the cache key
-      id: calc-cache-key-files
-      uses: ./.github/actions/cache-keys
-    - name: Set up pip cache
-      uses: re-actors/cache-python-deps@release/v1
-      with:
-        cache-key-for-dependency-files: >-
-          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
+        activate-environment: true
+        enable-cache: true
     - name: Install core libraries for build
-      run: python -Im pip install build
+      run: uv pip install build
     - name: Build sdists and pure-python wheel
       env:
         PIP_CONSTRAINT: requirements/cython.txt
@@ -243,65 +235,22 @@ jobs:
         merge-multiple: true
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.pyver }}
-        allow-prereleases: true
-    - name: >-
-        Calculate dependency files' combined hash value
-        for use in the cache key
-      id: calc-cache-key-files
-      uses: ./.github/actions/cache-keys
-    - name: Set up pip cache
-      uses: re-actors/cache-python-deps@release/v1
-      with:
-        cache-key-for-dependency-files: >-
-          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
+        activate-environment: true
+        enable-cache: true
     - name: Install dependencies
-      uses: py-actions/py-dependency-install@v4
-      with:
-        path: requirements/codspeed.txt
-    - name: Determine pre-compiled compatible wheel
-      env:
-        # NOTE: When `pip` is forced to colorize output piped into `jq`,
-        # NOTE: the latter can't parse it. So we're overriding the color
-        # NOTE: preference here via https://no-color.org.
-        # NOTE: Setting `FORCE_COLOR` to any value (including 0, an empty
-        # NOTE: string, or a "YAML null" `~`) doesn't have any effect and
-        # NOTE: `pip` (through its verndored copy of `rich`) treats the
-        # NOTE: presence of the variable as "force-color" regardless.
-        #
-        # NOTE: This doesn't actually work either, so we'll resort to unsetting
-        # NOTE: in the Bash script.
-        # NOTE: Ref: https://github.com/Textualize/rich/issues/2622
-        NO_COLOR: 1
-      id: wheel-file
-      run: >
-        echo -n path= | tee -a "${GITHUB_OUTPUT}"
-
-
-        unset FORCE_COLOR
-
-
-        python
-        -X utf8
-        -u -I
-        -m pip install
+      run: uv pip install -r requirements/codspeed.txt
+    - name: Install ${{ env.PROJECT_NAME }} from a pre-built wheel
+      run: >-
+        uv pip install
         --find-links=./dist
         --no-index
-        '${{ env.PROJECT_NAME }}'
-        --force-reinstall
-        --no-color
         --no-deps
+        --force-reinstall
         --only-binary=:all:
-        --dry-run
-        --report=-
-        --quiet
-        | jq --raw-output .install[].download_info.url
-        | tee -a "${GITHUB_OUTPUT}"
-      shell: bash
-    - name: Self-install
-      run: python -Im pip install '${{ steps.wheel-file.outputs.path }}'
+        '${{ env.PROJECT_NAME }}'
     - name: Produce the C-files for the Coverage.py Cython plugin
       if: >-  # Only works if the dists were built with line tracing
         !matrix.no-extensions
@@ -314,7 +263,7 @@ jobs:
       run: |
         set -eEuo pipefail
 
-        python -Im pip install expandvars
+        uv pip install expandvars
         python -m pep517_backend.cli translate-cython
       shell: bash
     - name: Disable the Cython.Coverage Produce plugin

--- a/CHANGES/241.contrib.rst
+++ b/CHANGES/241.contrib.rst
@@ -1,0 +1,6 @@
+Switched the CI test matrix from ``actions/setup-python`` to
+``astral-sh/setup-uv`` for installing interpreters, cutting the
+``Setup Python`` step from 40-58s to a few seconds on macOS and
+Windows runners for variants not in the hosted tool-cache
+(notably the free-threaded ``3.14t``)
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Swap `actions/setup-python@v6` for `astral-sh/setup-uv@v8.1.0` in
the two CI jobs that install a Python interpreter
(`build-pure-python-dists` and the matrix `test`), and go
uv-native for the surrounding `pip` calls. `activate-environment:
true` keeps `python` on PATH; `enable-cache: true` persists uv's
wheel cache across runs, replacing the
`re-actors/cache-python-deps` pip-cache wrapper. The
`py-actions/py-dependency-install` action and the `pip --dry-run
--report=- | jq` wheel-discovery trick both fold into single
`uv pip install` calls.

## Are there changes in behavior for the user?

No. This only affects CI runner provisioning. End-user-visible
behavior of `propcache` is unaffected.

The Codecov flag derived from
`steps.python-install.outputs.python-version` now reports the
matrix spec (`3.14t`) rather than the resolved patch (`3.14.5t`);
coarser, but easier to group across patch releases.

## Related issue number

Mirrors aio-libs/yarl#1704.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist — N/A (CI configuration)
- [x] Documentation reflects the changes — N/A (no user-visible change)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

Reproduces aio-libs/yarl#1704 in `propcache`. Motivation, from
yarl's PR #1682 run, where `Setup Python 3.14t` took 40s on
`macos-latest` and 58s on `windows-latest` for a test step that
ran in 9-18s. Linux has the slow variants in `hostedtoolcache`;
macOS/Windows do not. `astral-sh/setup-uv` fetches
python-build-standalone from a CDN, which is consistently a few
seconds across all three OSes.

The `re-actors/cache-python-deps` wrapper relied on `pip` being
present in the venv. With `setup-uv` and `activate-environment:
true` the venv is created without `--seed`, so pip is absent and
the wrapper's `python -Im pip cache dir` probe crashes the job;
going uv-native sidesteps that entirely and uses uv's own
`UV_CACHE_DIR` via `enable-cache: true`.

Local verification: `make doc-spelling` shows only the two
pre-existing failures on `master` (`subdirectory` in
`CHANGES/207.contrib.rst`, `postfix` in `CHANGES.rst:150`); no new
spelling issues. Pre-commit pass (yamllint, actionlint, codespell)
on the modified workflow.

</details>