### PR TITLE
ci: fall back to plain build frontend for odd-arch wheels

### DIFF
--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -74,6 +74,12 @@ jobs:
         # Build emulated architectures only if QEMU is set,
         # use default "auto" otherwise
         echo "CIBW_ARCHS_LINUX=${{ inputs.qemu }}" >> "${GITHUB_ENV}"
+        # Override pyproject.toml's `build[uv]` because the pypa odd-arch
+        # containers (as of the 2026.03.20-1 tag) do not ship `uv`
+        # preinstalled; without this override cibuildwheel fails with
+        # `Command ['which', 'uv'] failed with code 1` inside the
+        # QEMU-emulated manylinux/musllinux containers.
+        echo "CIBW_BUILD_FRONTEND=build" >> "${GITHUB_ENV}"
       shell: bash
 
     - name: Skip building some wheel tags
@@ -87,8 +93,11 @@ jobs:
       with:
         # `build-frontend = "build[uv]"` (pyproject.toml) requires uv to be
         # available on the runner for Windows and macOS. Installing
-        # cibuildwheel with the `uv` extra bundles uv with it; Linux
-        # already has uv inside the manylinux/musllinux container.
+        # cibuildwheel with the `uv` extra bundles uv with it; the
+        # tested-arch manylinux/musllinux containers also ship uv
+        # preinstalled. The odd-arch containers do not, so the
+        # `Prepare emulation` step above overrides
+        # `CIBW_BUILD_FRONTEND=build` when QEMU is in play.
         extras: uv
       env:
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2

--- a/CHANGES/246.contrib.rst
+++ b/CHANGES/246.contrib.rst
@@ -1,0 +1,5 @@
+Overrode ``CIBW_BUILD_FRONTEND=build`` for the QEMU-emulated
+odd-arch wheel matrix, since the pypa odd-arch container images
+do not ship ``uv`` preinstalled and the project's
+:file:`pyproject.toml` sets ``build-frontend = "build[uv]"``
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -8,6 +8,7 @@ GPG
 IPv
 PRs
 PYX
+QEMU
 Towncrier
 Twitter
 UTF
@@ -38,7 +39,10 @@ manylinux
 multi
 nightlies
 pre
+preinstalled
 propcache
+pypa
+pyproject
 rc
 reStructuredText
 reencoding


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Override `CIBW_BUILD_FRONTEND=build` for the QEMU-emulated
odd-arch wheel matrix (`aarch64`, `armv7l`, `ppc64le`,
`riscv64`, `s390x` x manylinux/musllinux) in
`.github/workflows/reusable-build-wheel.yml`, so `cibuildwheel`
uses plain `pip` to drive the per-ABI builds inside those
containers.

`pyproject.toml` sets `build-frontend = "build[uv]"`, which
requires a `uv` binary on `PATH` inside the build container.
The pypa tested-arch manylinux/musllinux images ship `uv`
preinstalled, but the odd-arch images do not, which makes
every odd-arch matrix cell fail at
`cibuildwheel: Command ['which', 'uv'] failed with code 1`.

The override lives in the existing `Prepare emulation` step
(which already runs only when `inputs.qemu` is set), keeping
the tested-arch matrix on `build[uv]` and falling back to
plain `build` only for the QEMU-emulated odd-arch matrix.

This is a port of [aio-libs/yarl#1720][1] adapted to
propcache's reusable-workflow structure.

[1]: https://github.com/aio-libs/yarl/pull/1720

## Are there changes in behavior for the user?

No user-visible API change. Restores production of odd-arch
wheels in future releases.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist; N/A, CI workflow change
- [ ] Documentation reflects the changes; N/A
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

- The `build-wheels-for-odd-archs` matrix is gated on `pre-deploy`,
  which only runs on tag pushes; this change cannot be smoke-tested
  on a PR. Verification path is the next tagged release.
- `make doc-spelling` runs clean on the news fragment locally; the
  two remaining warnings (`subdirectory` in `CHANGES/207.contrib.rst`
  and `postfix` in `CHANGES.rst:168`) are pre-existing on `master`
  and not introduced by this change. CI's `spellcheck-docs` is
  currently green on master, so the local-vs-CI discrepancy is
  likely `sphinxcontrib-towncrier` version drift, the same
  environment quirk noted on the upstream yarl PR.
- New wordlist entries: `QEMU`, `preinstalled`, `pypa`, `pyproject`.
- Pre-commit ran clean on the commit.

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco before flipping out of draft.

</details>