### PR TITLE
ci: make the deploy job re-runnable after a partial failure

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -622,7 +622,29 @@ jobs:
     - name: Login
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+    - name: Check whether the GitHub Release already exists
+      # Allows re-running the deploy job after a partial failure (e.g. PyPI
+      # upload error) without the Make Release step failing with HTTP 422
+      # because the tag/release was created on a prior attempt. Treat
+      # only the literal `release not found` reply as "does not exist";
+      # other failures (auth, rate-limit, network) re-raise so the job
+      # fails loudly instead of falling through to Make Release.
+      id: gh-release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+            >/dev/null 2>err; then
+          echo 'exists=true' >> "${GITHUB_OUTPUT}"
+        elif grep -qx 'release not found' err; then
+          echo 'exists=false' >> "${GITHUB_OUTPUT}"
+        else
+          cat err >&2
+          exit 1
+        fi
     - name: Make Release
+      if: steps.gh-release.outputs.exists != 'true'
       uses: aio-libs/create-release@v1.6.6
       with:
         changes_file: CHANGES.rst
@@ -638,6 +660,10 @@ jobs:
     - name: >-
         Publish 🐍📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        # Allow re-running the deploy job after a partial PyPI upload
+        # without failing on dists that were already published.
+        skip-existing: true
 
     - name: Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@v3.3.0

--- a/CHANGES/247.contrib.rst
+++ b/CHANGES/247.contrib.rst
@@ -1,0 +1,5 @@
+Allowed re-running the deploy job after a partial release failure: the
+``Make Release`` step now skips when the GitHub Release already exists,
+and the PyPI publish step uses ``skip-existing`` so dists that were
+already uploaded on a prior attempt do not break the retry
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Make the ``deploy`` job in ``ci-cd.yml`` re-runnable after a partial
release failure.

- The ``Make Release`` step is now gated on a preceding ``gh release
  view`` check, so it is skipped when the GitHub Release for the tag
  already exists (instead of failing with ``HTTP 422 already_exists``).
- The PyPI publish step is invoked with ``skip-existing: true`` so a
  retry does not fail on dists that were already uploaded.

Concretely, this means that if PyPI returns a 5xx (or any other
transient failure after the GitHub Release was created), the maintainer
can re-run the failed ``deploy`` job instead of cutting a brand-new
release. This mirrors the equivalent change in yarl (aio-libs/yarl#1721),
where the v1.24.0 cut hit exactly this scenario.

The existence check matches only the literal ``release not found``
reply for the not-exists branch; auth, rate-limit, or transient network
failures re-raise so the deploy job fails loudly with the real error
instead of falling through.

## Are there changes in behavior for the user?

No. This only affects how the release pipeline recovers from partial
failures; the produced artifacts and release are unchanged.

## Related issue number

None; ports aio-libs/yarl#1721 to propcache.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist; N/A (CI workflow change, exercised by the next release run)
- [ ] Documentation reflects the changes; N/A
- [x] Add a new news fragment into the ``CHANGES/`` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.

Local checks:
- ``make doc-spelling``; the new fragment introduces no new misspellings (the 2 reported warnings are pre-existing on ``master``: ``subdirectory`` in ``CHANGES/207.contrib.rst`` and ``postfix`` in ``CHANGES.rst:168``).
- ``yamllint``; passes for the workflow change.
- ``python -c "import yaml; yaml.safe_load(...)"``; workflow parses cleanly.
</details>