### PR TITLE
ci: build aarch64 and armv7l wheels on native ARM runners

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -569,10 +569,35 @@ jobs:
         exclude:
         - tag: ''
           qemu: armv7l
+        include:
+        # Build aarch64 natively on the GH-hosted ARM runner instead of
+        # x86_64-under-QEMU; this drops the build from ~40 min of
+        # emulation to a few minutes of native execution. Each
+        # (qemu, tag) combo is listed explicitly so the include
+        # unambiguously augments the existing matrix cell rather than
+        # relying on the partial-key merge behaviour of `matrix.include`.
+        - qemu: aarch64
+          tag: ''
+          runner-vm-os: ubuntu-24.04-arm
+          native-arch: true
+        - qemu: aarch64
+          tag: musllinux
+          runner-vm-os: ubuntu-24.04-arm
+          native-arch: true
+        # armv7l also moves to aarch64 hosts. QEMU stays registered so
+        # binfmt picks up the 32-bit ARM userspace handler regardless of
+        # whether the host kernel has CONFIG_COMPAT enabled. Even with
+        # emulation, aarch64-on-aarch64 hosting beats x86_64 by a wide
+        # margin. armv7l's ``tag: ''`` cell is excluded above, so only
+        # the musllinux cell is overridden here.
+        - qemu: armv7l
+          tag: musllinux
+          runner-vm-os: ubuntu-24.04-arm
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
-      os: ubuntu-latest
+      os: ${{ matrix.runner-vm-os || 'ubuntu-latest' }}
       qemu: ${{ matrix.qemu }}
+      native-arch: ${{ matrix.native-arch && true || false }}
       tag: ${{ matrix.tag }}
       wheel-tags-to-skip: >-
         ${{

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -24,6 +24,14 @@ on:
         default: ''
         required: false
         type: string
+      native-arch:
+        description: >-
+          Whether the runner natively executes the architecture named
+          by ``qemu`` (so the QEMU userspace handler does not need to
+          be registered). Defaults to ``false``.
+        default: false
+        required: false
+        type: boolean
       tag:
         description: Build platform tag wheels
         default: ''
@@ -59,7 +67,7 @@ jobs:
         workflow-artifact-name: ${{ inputs.dists-artifact-name }}
 
     - name: Set up QEMU
-      if: inputs.qemu
+      if: inputs.qemu && ! inputs.native-arch
       uses: docker/setup-qemu-action@v4
       with:
         platforms: all
@@ -68,17 +76,20 @@ jobs:
         # xref https://github.com/tonistiigi/binfmt/issues/215
         image: tonistiigi/binfmt:qemu-v8.1.5
       id: qemu
-    - name: Prepare emulation
+    - name: Prepare cross-arch build environment
       if: inputs.qemu
       run: |
-        # Build emulated architectures only if QEMU is set,
-        # use default "auto" otherwise
+        # Tell cibuildwheel which Linux arch to build for; the default
+        # of "auto" would only build the host arch, but the odd-arch
+        # matrix may pin a different target even when running natively.
         echo "CIBW_ARCHS_LINUX=${{ inputs.qemu }}" >> "${GITHUB_ENV}"
         # Override pyproject.toml's `build[uv]` because the pypa odd-arch
-        # containers (as of the 2026.03.20-1 tag) do not ship `uv`
-        # preinstalled; without this override cibuildwheel fails with
-        # `Command ['which', 'uv'] failed with code 1` inside the
-        # QEMU-emulated manylinux/musllinux containers.
+        # manylinux/musllinux container images (as of the 2026.03.20-1
+        # tag) do not ship `uv` preinstalled; without this override
+        # cibuildwheel fails with `Command ['which', 'uv'] failed with
+        # code 1` inside those containers. The container image is the
+        # same whether the host runs natively or under QEMU, so this
+        # override is still required on native ARM runners.
         echo "CIBW_BUILD_FRONTEND=build" >> "${GITHUB_ENV}"
       shell: bash
 

--- a/CHANGES/248.contrib.rst
+++ b/CHANGES/248.contrib.rst
@@ -1,0 +1,5 @@
+Switched the aarch64 and armv7l wheel builds to GitHub's native ARM
+runners. The aarch64 wheels now build without QEMU emulation, and
+armv7l runs on aarch64 hosts so its 32-bit ARM execution is far
+cheaper than the previous aarch64-on-x86_64 path
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -12,7 +12,9 @@ QEMU
 Towncrier
 Twitter
 UTF
+aarch
 aiohttp
+armv
 backend
 boolean
 booleans


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Move the aarch64 and armv7l legs of the release wheel matrix off the
x86_64 QEMU path and onto GitHub's public ``ubuntu-24.04-arm`` hosted
runner. aarch64 now builds natively with no emulation. armv7l still
gets ``docker/setup-qemu-action`` so binfmt registers a 32-bit ARM
handler whether or not the host kernel ships ``CONFIG_COMPAT``; even
under emulation, running on an aarch64 host is far cheaper than the
previous aarch64-on-x86_64 layout.

ppc64le, s390x, and riscv64 keep the ``ubuntu-latest`` + QEMU setup
since there are no native GH-hosted runners for those.

The matrix gains an ``include:`` block that overrides ``runner-vm-os``
and a ``native-arch`` flag per arch; each ``(qemu, tag)`` combo is
listed explicitly so the include unambiguously augments the existing
matrix cell rather than relying on the partial-key merge behaviour of
``matrix.include``. The reusable ``reusable-build-wheel.yml`` gains a
``native-arch`` boolean input that gates the ``Set up QEMU`` step
while keeping the cross-arch environment step (``CIBW_ARCHS_LINUX``
and ``CIBW_BUILD_FRONTEND=build``) running on native ARM runs too,
because the manylinux/musllinux odd-arch container images are the
same regardless of host.

Ports aio-libs/yarl#1724 to propcache.

## Are there changes in behavior for the user?

No. Wheels are still built for the same architectures and tags; only
the host that builds them changes. Release CI time on the aarch64
leg should drop from roughly 40 minutes to a few minutes.

## Related issue number

N/A; ports aio-libs/yarl#1724.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist ``N/A (CI-only change)``
- [ ] Documentation reflects the changes ``N/A (no user-facing docs)``
- [x] Add a new news fragment into the ``CHANGES/`` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.

Local validation:

- pre-commit hooks (yamllint, actionlint, GH workflow validation, codespell, end-of-file, trailing whitespace, file-contents-sorter on the wordlist) all passed on commit.
- ``python -c "yaml.safe_load(...)"`` confirms both workflow files parse cleanly, including the matrix ``include:`` shape and the ``${{ matrix.runner-vm-os || 'ubuntu-latest' }}`` / ``${{ matrix.native-arch && true || false }}`` expressions.
- ``make doc-spelling`` reports only the 2 pre-existing misspellings on ``master`` (``subdirectory`` in ``CHANGES/207.contrib.rst`` and ``postfix`` in ``CHANGES.rst:168``). The new fragment introduces ``aarch`` and ``armv``, both added to ``docs/spelling_wordlist.txt``.

Not validated locally: actual native-ARM cibuildwheel run. The runner label and matrix wiring look correct, but the real proof is the first CI run on this branch.
</details>