### PR TITLE
ci: honor cython pin under build[uv] with UV_CONSTRAINT

### DIFF
--- a/CHANGES/249.contrib.rst
+++ b/CHANGES/249.contrib.rst
@@ -1,0 +1,7 @@
+Added ``UV_CONSTRAINT`` and ``UV_BUILD_CONSTRAINT`` alongside
+``PIP_CONSTRAINT`` and ``PIP_BUILD_CONSTRAINT`` in the
+``cibuildwheel`` environment so the :file:`requirements/cython.txt`
+pin is honored under the ``build[uv]`` frontend; ``uv pip``
+ignores the ``PIP_`` variables and reads only the ``UV_`` ones,
+while the ``PIP_`` variants are kept for the pip fallback path
+-- by :user:`bdraco`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,12 @@ skip = "pp*"
 COLOR = "yes"
 FORCE_COLOR = "1"
 MYPY_FORCE_COLOR = "1"
+PIP_BUILD_CONSTRAINT = "requirements/cython.txt"
 PIP_CONSTRAINT = "requirements/cython.txt"
 PRE_COMMIT_COLOR = "always"
 PY_COLORS = "1"
+UV_BUILD_CONSTRAINT = "requirements/cython.txt"
+UV_CONSTRAINT = "requirements/cython.txt"
 
 [tool.cibuildwheel.config-settings]
 pure-python = "false"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add ``UV_CONSTRAINT`` and ``UV_BUILD_CONSTRAINT`` to the
``[tool.cibuildwheel.environment]`` block, mirroring the existing
``PIP_CONSTRAINT`` entry (and adding ``PIP_BUILD_CONSTRAINT`` for
parity). All four point at ``requirements/cython.txt``.

Since the cibuildwheel build frontend was switched to ``build[uv]``,
the ``PIP_CONSTRAINT`` env var is silently ignored during the wheel
build; ``uv pip`` reads only ``UV_CONSTRAINT`` / ``UV_BUILD_CONSTRAINT``.
Empirically, with ``python -m build --installer=uv`` and
``PIP_CONSTRAINT`` set to pin an older Cython, uv still resolves the
latest release; setting ``UV_CONSTRAINT`` to the same file pins it
correctly. The ``PIP_`` variants are kept because the odd-arch matrix
in ``ci-cd.yml`` overrides ``CIBW_BUILD_FRONTEND=build`` (pip frontend)
on containers that do not ship ``uv``.

## Are there changes in behavior for the user?

No user-facing change; the Cython version pin used at wheel build
time is now actually enforced under the ``build[uv]`` frontend,
matching the intent of the existing ``PIP_CONSTRAINT`` line.

## Is it a substantial burden for the maintainers to support this?

No; a few extra env vars in ``pyproject.toml``.

## Related issue number

Port of aio-libs/yarl#1729.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A, CI/packaging env change)
- [ ] Documentation reflects the changes (N/A)
- [x] Add a new news fragment into the ``CHANGES/`` folder